### PR TITLE
added useChecklistItems

### DIFF
--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -35,10 +35,7 @@ export const Item: React.FunctionComponent = (props) => {
       <p>Getting info for {itemNum}</p>
       <p>Response: {item.Title}</p>
 
-      <CheckList
-        CheckListItems={checklisItems || []}
-        loading={!checklisItems}
-      />
+      <CheckList CheckListItems={checklisItems} />
 
       <Button appearance="primary" onClick={updateItem}>
         Update

--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -1,18 +1,15 @@
 import { Button } from "@fluentui/react-components";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { ICheckListItem } from "./api/CheckListItemApi";
 import { IItem, ItemApiConfig } from "./api/ItemApi";
 import { CheckList } from "./components/CheckList/CheckList";
-import { CheckListItemApiConfig } from "./api/CheckListItemApi";
+import { useChecklistItems } from "./api/CheckListItemApi";
 
 export const Item: React.FunctionComponent = (props) => {
   const { itemNum } = useParams();
   const itemApi = ItemApiConfig.getApi();
-  const checklistItemApi = CheckListItemApiConfig.getApi();
   const [item, setItem] = useState<IItem>({ Id: 0, Title: "" });
-  const [checklisItems, setChecklistItems] = useState<ICheckListItem[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
+  const checklisItems = useChecklistItems(Number(itemNum));
 
   async function updateItem() {
     let updatedItem = { ...item, Title: "TEST" };
@@ -21,23 +18,14 @@ export const Item: React.FunctionComponent = (props) => {
   }
 
   useEffect(() => {
-    async function loadItem() {
-      let res = await itemApi.getItemById(Number(itemNum));
+    const loadItem = async () => {
+      const res = await itemApi.getItemById(Number(itemNum));
       if (res) {
         setItem(res);
       }
-    }
-
-    async function fetchChecklistItems() {
-      let items = await checklistItemApi.getItemsById(Number(itemNum));
-      if (items) {
-        setChecklistItems(items);
-        setLoading(false);
-      }
-    }
+    };
 
     loadItem();
-    fetchChecklistItems();
   }, [itemNum]);
 
   return (
@@ -47,7 +35,10 @@ export const Item: React.FunctionComponent = (props) => {
       <p>Getting info for {itemNum}</p>
       <p>Response: {item.Title}</p>
 
-      <CheckList CheckListItems={checklisItems} loading={loading} />
+      <CheckList
+        CheckListItems={checklisItems || []}
+        loading={!checklisItems}
+      />
 
       <Button appearance="primary" onClick={updateItem}>
         Update

--- a/src/api/CheckListItemApi.ts
+++ b/src/api/CheckListItemApi.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { spWebContext } from "../providers/SPWebContext";
 import { ApiError } from "./InternalErrors";
 import { DateTime } from "luxon";
@@ -12,10 +13,10 @@ export interface ICheckListItem {
 
 export interface ICheckListItemApi {
   /**
-   * Gets the items based on the checklist ID.
+   * Gets the items based on the checklist Id.
    *
-   * @param Id The ID of the item to retrieve from SharePoint
-   * @returns The IITem for the given ID
+   * @param Id The Id of the item to retrieve from SharePoint
+   * @returns The ICheckListItem for the given Id
    */
   getItemsById(Id: number): Promise<ICheckListItem[] | undefined>;
 }
@@ -90,3 +91,28 @@ export class CheckListItemApiConfig {
     return this.checklistApi;
   }
 }
+
+/**
+ * Gets the checklist items based on the checklist Id.
+ *
+ * @param Id The Id of the parent request to retrieve from SharePoint
+ */
+export const useChecklistItems = (Id: number) => {
+  // Initialize as null (have not fetched yet)
+  // Then update to empty set or data once data retrieved
+  const [checklisItems, setChecklistItems] = useState<ICheckListItem[] | null>(
+    null
+  );
+
+  useEffect(() => {
+    const fetchChecklistItems = async () => {
+      const checklistItemApi = CheckListItemApiConfig.getApi();
+      const items = await checklistItemApi.getItemsById(Id);
+      setChecklistItems(items || []);
+    };
+
+    fetchChecklistItems();
+  }, [Id]);
+
+  return checklisItems;
+};

--- a/src/components/CheckList/CheckList.tsx
+++ b/src/components/CheckList/CheckList.tsx
@@ -4,8 +4,7 @@ import { ShimmeredDetailsList } from "@fluentui/react/lib/ShimmeredDetailsList";
 import React from "react";
 
 export interface ICheckList {
-  CheckListItems: ICheckListItem[];
-  loading?: boolean;
+  CheckListItems: ICheckListItem[] | null;
 }
 
 export const CheckList: React.FunctionComponent<ICheckList> = (props) => {
@@ -48,9 +47,9 @@ export const CheckList: React.FunctionComponent<ICheckList> = (props) => {
   return (
     <div>
       <ShimmeredDetailsList
-        items={props.CheckListItems}
+        items={props.CheckListItems || []}
         columns={columns}
-        enableShimmer={props.loading}
+        enableShimmer={!props.CheckListItems}
       />
     </div>
   );


### PR DESCRIPTION
Moved checklist fetch logic from Item.tsx to a reusable useChecklistItems hook.
Hook returns null as the default value, then returns an array after fetching is complete.
Loading logic for shimmer is now internal to CheckList.tsx (null will shimmer, an array will load the array)
