### PR TITLE
Update IInForm to be IInRequest

### DIFF
--- a/src/api/RequestApi.ts
+++ b/src/api/RequestApi.ts
@@ -14,7 +14,7 @@ const getMyRequests = async () => {
   if (process.env.NODE_ENV === "development") {
     return Promise.resolve(testItems);
   } else if (userId === undefined) {
-    return Promise.reject([] as IInForm[]);
+    return Promise.reject([] as IInRequest[]);
   } else {
     const response = await spWebContext.web.lists
       .getByTitle("Items")
@@ -27,7 +27,7 @@ const getMyRequests = async () => {
       const CACExpiration = new Date(request.CACExpiration);
       const completionDate = new Date(request.completionDate);
       const newRequest = { ...request, eta, CACExpiration, completionDate };
-      return newRequest as IInForm;
+      return newRequest as IInRequest;
     });
   }
 };
@@ -40,11 +40,11 @@ export const useMyRequests = () => {
 };
 
 // create PnP JS response interface for the InForm
-// This extends the IInForm -- currently identical, but may need to vary when pulling in SPData
-type IResponseItem = IInForm;
+// This extends the IInRequest -- currently identical, but may need to vary when pulling in SPData
+type IResponseItem = IInRequest;
 
 // create IItem item to work with it internally
-export type IInForm = {
+export type IInRequest = {
   /** Required - Will be -1 for NewForms that haven't been saved yet */
   Id: number;
   /** Required - Contains the Employee's Name */
@@ -97,7 +97,7 @@ export interface IInFormApi {
    *
    * @param requirementsRequest The RequirementsRequest to be saved/updated
    */
-  updateItem(IItem: IInForm): Promise<IItemUpdateResult>;
+  updateItem(IItem: IInRequest): Promise<IItemUpdateResult>;
 }
 
 export class RequestApi implements IInFormApi {
@@ -107,7 +107,7 @@ export class RequestApi implements IInFormApi {
     try {
       // use map to convert IResponseItem[] into our internal object IItem[]
       const response: IResponseItem = await this.itemList.items.getById(ID)();
-      const items: IInForm = {
+      const items: IInRequest = {
         Id: response.Id,
         empName: response.empName,
         empType: response.empType,
@@ -147,7 +147,7 @@ export class RequestApi implements IInFormApi {
     }
   }
 
-  async updateItem(Item: IInForm): Promise<IItemUpdateResult> {
+  async updateItem(Item: IInRequest): Promise<IItemUpdateResult> {
     try {
       return await this.itemList.items.getById(Item.Id).update(Item);
     } catch (e) {
@@ -229,7 +229,7 @@ export class RequestApiDev implements IInFormApi {
     return testItems.find((r) => r.Id === ID);
   }
 
-  async updateItem(Item: IInForm): Promise<IItemUpdateResult | any> {
+  async updateItem(Item: IInRequest): Promise<IItemUpdateResult | any> {
     await this.sleep();
     return (testItems[testItems.findIndex((r) => r.Id === Item.Id)] = Item);
   }

--- a/src/components/InRequest/InRequest.tsx
+++ b/src/components/InRequest/InRequest.tsx
@@ -22,7 +22,7 @@ import {
   tokens,
 } from "@fluentui/react-components";
 import { UserContext } from "../../providers/UserProvider";
-import { IInForm, RequestApiConfig } from "../../api/RequestApi";
+import { IInRequest, RequestApiConfig } from "../../api/RequestApi";
 import { InRequestViewCompact } from "./InRequestViewCompact";
 import { InRequestEditPanel } from "./InRequestEditPanel";
 import { useForm, Controller, SubmitHandler } from "react-hook-form";
@@ -61,13 +61,13 @@ export const InRequest: FunctionComponent<any> = (props) => {
   const userContext = useContext(UserContext);
   const email = useEmail();
 
-  const [formData, setFormData] = useState<IInForm | undefined>(undefined);
+  const [formData, setFormData] = useState<IInRequest | undefined>(undefined);
 
   /* Boolean state for determining whether or not the Edit Panel is shown */
   const [isEditPanelOpen, { setTrue: showEditPanel, setFalse: hideEditPanel }] =
     useBoolean(false);
 
-  // TODO -- Look to see if when v8 of react-hook-form released if you can properly set useForm to use the type IInForm
+  // TODO -- Look to see if when v8 of react-hook-form released if you can properly set useForm to use the type IInRequest
   //  See -  https://github.com/react-hook-form/react-hook-form/issues/6679
   const {
     control,
@@ -151,7 +151,7 @@ export const InRequest: FunctionComponent<any> = (props) => {
     return <>Loading...</>;
   }
 
-  const createNewRequest: SubmitHandler<IInForm> = async (data) => {
+  const createNewRequest: SubmitHandler<IInRequest> = async (data) => {
     /* Validation has passed, so create the new Request */
     await email.sendInRequestSubmitEmail(data);
     /* TODO - Save the New Request */
@@ -159,7 +159,7 @@ export const InRequest: FunctionComponent<any> = (props) => {
     console.log(JSON.stringify(data));
   };
 
-  const updateRequest: SubmitHandler<IInForm> = (data) => {
+  const updateRequest: SubmitHandler<IInRequest> = (data) => {
     /* Validation has passed, so update the request */
     let dataCopy = { ...data };
     // If it isn't a Civ/Mil, ensure values depending on Civ/Mil only are set correctly
@@ -588,7 +588,7 @@ export const InRequest: FunctionComponent<any> = (props) => {
       case INFORMVIEWS.COMPACT:
         return (
           <>
-            <InRequestViewCompact formData={formData as IInForm} />{" "}
+            <InRequestViewCompact formData={formData as IInRequest} />{" "}
             <Button
               appearance="primary"
               className="floatRight"

--- a/src/components/InRequest/InRequestViewCompact.tsx
+++ b/src/components/InRequest/InRequestViewCompact.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from "react";
 import { EMPTYPES } from "../../constants/EmpTypes";
 import { makeStyles, Label, Text } from "@fluentui/react-components";
-import { IInForm } from "../../api/RequestApi";
+import { IInRequest } from "../../api/RequestApi";
 
 /* FluentUI Styling */
 const useStyles = makeStyles({
@@ -16,14 +16,14 @@ const useStyles = makeStyles({
 });
 
 export interface IInRequestViewCompact {
-  formData: IInForm;
+  formData: IInRequest;
 }
 
 export const InRequestViewCompact: FunctionComponent<IInRequestViewCompact> = (
   props
 ) => {
   const classes = useStyles();
-  const formData: IInForm = props.formData;
+  const formData: IInRequest = props.formData;
 
   // Function used to display the Employee Type in a shortened format.
   // If it is a Civilian add New/Existing after depending on the selection

--- a/src/hooks/useEmail.tsx
+++ b/src/hooks/useEmail.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { EmailApiConfig } from "../api/EmailApi";
 import { EmailError } from "../api/InternalErrors";
-import { IInForm } from "../api/RequestApi";
+import { IInRequest } from "../api/RequestApi";
 import { IPerson } from "../api/UserApi";
 import { useError } from "./useError";
 
@@ -13,7 +13,7 @@ export interface IEmailSender {
     body: string,
     cc?: IPerson[]
   ) => Promise<void>;
-  sendInRequestSubmitEmail: (process: IInForm) => Promise<void>;
+  sendInRequestSubmitEmail: (process: IInRequest) => Promise<void>;
 }
 
 export function useEmail(): IEmailSender {
@@ -44,7 +44,9 @@ export function useEmail(): IEmailSender {
     }
   };
 
-  const sendInRequestSubmitEmail = async (request: IInForm): Promise<void> => {
+  const sendInRequestSubmitEmail = async (
+    request: IInRequest
+  ): Promise<void> => {
     // TODO - Populate with whom it should actually go to rather than selected Supervisor
     let to = [request.supGovLead] as IPerson[]; // TODO -- Don't use AS here -- Work issue #12 to standardize person object
     let subject = `In Process: ${request.empName} has been submitted`;


### PR DESCRIPTION
Leveraged VSCode rename capability to rename IInForm to IInRequest to better reflect it is an InProcessing Request and not a Form.  Had to manually update a few comments.