### PR TITLE
Refactor/people

### DIFF
--- a/src/api/RequestApi.ts
+++ b/src/api/RequestApi.ts
@@ -180,7 +180,7 @@ export const useAddRequest = () => {
   const queryClient = useQueryClient();
   return useMutation(
     ["requests"],
-    (newRequest: IInRequest) => {
+    async (newRequest: IInRequest) => {
       if (process.env.NODE_ENV === "development") {
         let returnRequest = {} as IItemAddResult;
         returnRequest.data = { ...newRequest, Id: 4 };
@@ -188,7 +188,7 @@ export const useAddRequest = () => {
       } else {
         return spWebContext.web.lists
           .getByTitle("Items")
-          .items.add(transformInRequestToSP(newRequest));
+          .items.add(await transformInRequestToSP(newRequest));
       }
     },
     {

--- a/src/components/InRequest/InRequest.tsx
+++ b/src/components/InRequest/InRequest.tsx
@@ -18,7 +18,7 @@ export const InRequest: FunctionComponent<IInRequest> = (props) => {
     useBoolean(false);
 
   //** Is the Current User the Superviosr/Gov Lead of this Request */
-  const isSupervisor = request.data?.supGovLead.SPUserId === currentUser.Id;
+  const isSupervisor = request.data?.supGovLead.Id === currentUser.Id;
 
   if (request.data) {
     return (

--- a/src/components/InRequest/InRequestEditPanel.tsx
+++ b/src/components/InRequest/InRequestEditPanel.tsx
@@ -213,8 +213,13 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                     aria-describedby="employeeErr"
                     selectedItems={value}
                     updatePeople={(items) => {
-                      setValue("empName", items[0] ? items[0].text : "");
-                      onChange(items);
+                      if (items?.[0]) {
+                        setValue("empName", items[0].text);
+                        onChange(items[0]);
+                      } else {
+                        setValue("empName", "");
+                        onChange([]);
+                      }
                     }}
                   />
                 )}
@@ -615,7 +620,13 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                     ariaLabel="Supervisor/Government Lead"
                     aria-describedby="supGovLeadErr"
                     selectedItems={value}
-                    updatePeople={onChange}
+                    updatePeople={(items) => {
+                      if (items?.[0]) {
+                        onChange(items[0]);
+                      } else {
+                        onChange([]);
+                      }
+                    }}
                   />
                 )}
               />

--- a/src/components/InRequest/InRequestEditPanel.tsx
+++ b/src/components/InRequest/InRequestEditPanel.tsx
@@ -211,15 +211,10 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                   <PeoplePicker
                     ariaLabel="Employee"
                     aria-describedby="employeeErr"
-                    defaultValue={value}
+                    selectedItems={value}
                     updatePeople={(items) => {
-                      if (items[0]) {
-                        setValue("empName", items[0].text);
-                        onChange(items[0]);
-                      } else {
-                        setValue("empName", "");
-                        onChange();
-                      }
+                      setValue("empName", items[0] ? items[0].text : "");
+                      onChange(items);
                     }}
                   />
                 )}
@@ -254,8 +249,8 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                 render={({ field }) => (
                   <Input
                     {...field}
-                    key={employee?.text ? employee.text : "empName"}
-                    disabled={employee?.text ? true : false}
+                    key={employee?.[0] ? employee[0].text : "empName"}
+                    disabled={employee?.[0] ? true : false}
                     aria-describedby="empNameErr"
                     id="empNameId"
                     placeholder="Supply a manually entered name to be used until they are in the GAL.  Example 'Doe, Jack E'"
@@ -619,14 +614,8 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                   <PeoplePicker
                     ariaLabel="Supervisor/Government Lead"
                     aria-describedby="supGovLeadErr"
-                    defaultValue={value}
-                    updatePeople={(items) => {
-                      if (items[0]) {
-                        onChange(items[0]);
-                      } else {
-                        onChange();
-                      }
-                    }}
+                    selectedItems={value}
+                    updatePeople={onChange}
                   />
                 )}
               />

--- a/src/components/InRequest/InRequestEditPanel.tsx
+++ b/src/components/InRequest/InRequestEditPanel.tsx
@@ -254,7 +254,7 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                 render={({ field }) => (
                   <Input
                     {...field}
-                    key={employee?.[0] ? employee[0].text : "empName"}
+                    key={employee?.text ? employee.text : "empName"}
                     disabled={employee?.text ? true : false}
                     aria-describedby="empNameErr"
                     id="empNameId"

--- a/src/components/InRequest/InRequestEditPanel.tsx
+++ b/src/components/InRequest/InRequestEditPanel.tsx
@@ -255,7 +255,7 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                   <Input
                     {...field}
                     key={employee?.[0] ? employee[0].text : "empName"}
-                    disabled={employee?.[0] ? true : false}
+                    disabled={employee?.text ? true : false}
                     aria-describedby="empNameErr"
                     id="empNameId"
                     placeholder="Supply a manually entered name to be used until they are in the GAL.  Example 'Doe, Jack E'"

--- a/src/components/InRequest/InRequestNewForm.tsx
+++ b/src/components/InRequest/InRequestNewForm.tsx
@@ -149,8 +149,13 @@ export const InRequestNewForm = () => {
               aria-describedby="employeeErr"
               selectedItems={value}
               updatePeople={(items) => {
-                setValue("empName", items[0] ? items[0].text : "");
-                onChange(items);
+                if (items?.[0]) {
+                  setValue("empName", items[0].text);
+                  onChange(items[0]);
+                } else {
+                  setValue("empName", "");
+                  onChange([]);
+                }
               }}
             />
           )}
@@ -540,7 +545,15 @@ export const InRequestNewForm = () => {
               ariaLabel="Supervisor/Government Lead"
               aria-describedby="supGovLeadErr"
               selectedItems={value}
-              updatePeople={onChange}
+              updatePeople={(items) => {
+                if (items?.[0]) {
+                  setValue("empName", items[0].text);
+                  onChange(items[0]);
+                } else {
+                  setValue("empName", "");
+                  onChange([]);
+                }
+              }}
             />
           )}
         />

--- a/src/components/InRequest/InRequestNewForm.tsx
+++ b/src/components/InRequest/InRequestNewForm.tsx
@@ -190,7 +190,7 @@ export const InRequestNewForm = () => {
           render={({ field }) => (
             <Input
               {...field}
-              key={employee?.[0] ? employee[0].text : "empName"}
+              key={employee?.text ? employee.text : "empName"}
               disabled={employee?.text ? true : false}
               aria-describedby="empNameErr"
               id="empNameId"

--- a/src/components/InRequest/InRequestNewForm.tsx
+++ b/src/components/InRequest/InRequestNewForm.tsx
@@ -191,7 +191,7 @@ export const InRequestNewForm = () => {
             <Input
               {...field}
               key={employee?.[0] ? employee[0].text : "empName"}
-              disabled={employee?.[0] ? true : false}
+              disabled={employee?.text ? true : false}
               aria-describedby="empNameErr"
               id="empNameId"
               placeholder="Supply a manually entered name to be used until they are in the GAL.  Example 'Doe, Jack E'"

--- a/src/components/InRequest/InRequestNewForm.tsx
+++ b/src/components/InRequest/InRequestNewForm.tsx
@@ -147,15 +147,10 @@ export const InRequestNewForm = () => {
             <PeoplePicker
               ariaLabel="Employee"
               aria-describedby="employeeErr"
-              defaultValue={value}
+              selectedItems={value}
               updatePeople={(items) => {
-                if (items[0]) {
-                  setValue("empName", items[0].text);
-                  onChange(items[0]);
-                } else {
-                  setValue("empName", "");
-                  onChange();
-                }
+                setValue("empName", items[0] ? items[0].text : "");
+                onChange(items);
               }}
             />
           )}
@@ -190,8 +185,8 @@ export const InRequestNewForm = () => {
           render={({ field }) => (
             <Input
               {...field}
-              key={employee?.text ? employee.text : "empName"}
-              disabled={employee?.text ? true : false}
+              key={employee?.[0] ? employee[0].text : "empName"}
+              disabled={employee?.[0] ? true : false}
               aria-describedby="empNameErr"
               id="empNameId"
               placeholder="Supply a manually entered name to be used until they are in the GAL.  Example 'Doe, Jack E'"
@@ -544,14 +539,8 @@ export const InRequestNewForm = () => {
             <PeoplePicker
               ariaLabel="Supervisor/Government Lead"
               aria-describedby="supGovLeadErr"
-              defaultValue={value}
-              updatePeople={(items) => {
-                if (items[0]) {
-                  onChange(items[0]);
-                } else {
-                  onChange();
-                }
-              }}
+              selectedItems={value}
+              updatePeople={onChange}
             />
           )}
         />

--- a/src/components/PeoplePicker/PeoplePicker.tsx
+++ b/src/components/PeoplePicker/PeoplePicker.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useEffect, useRef, useState } from "react";
+import { FunctionComponent, useRef, useState } from "react";
 import { IPersonaProps } from "@fluentui/react/lib/Persona";
 import {
   IBasePicker,
@@ -32,30 +32,25 @@ export interface SPPersona extends IPersonaProps {
 interface IPeoplePickerProps {
   /** Required - The text used to label this people picker for screenreaders */
   ariaLabel: string;
-  /** Optional - The people to pre-populate the People Picker with */
-  defaultValue?: SPPersona[] | SPPersona;
   readOnly?: boolean;
   required?: boolean;
   /** Optional - Limit the People Picker to only allow selection of specific number -- Defaults to 1 */
   itemLimit?: number;
   updatePeople: (p: SPPersona[]) => void;
+  selectedItems: SPPersona[] | SPPersona;
 }
 
 export const PeoplePicker: FunctionComponent<IPeoplePickerProps> = (props) => {
-  const [currentSelectedItems, setCurrentSelectedItems] = useState<
-    IPersonaProps[]
-  >([]);
-  const [peopleList] = useState<IPersonaProps[]>(people);
+  let selectedItems: SPPersona[];
+  if (Array.isArray(props.selectedItems)) {
+    selectedItems = [...props.selectedItems];
+  } else if (props.selectedItems) {
+    selectedItems = [{ ...props.selectedItems }];
+  } else {
+    selectedItems = [];
+  }
 
-  useEffect(() => {
-    let personas: SPPersona[] = [];
-    if (Array.isArray(props.defaultValue)) {
-      personas = [...props.defaultValue];
-    } else if (props.defaultValue) {
-      personas = [{ ...props.defaultValue }];
-    }
-    setCurrentSelectedItems(personas);
-  }, [props.defaultValue]);
+  const [peopleList] = useState<IPersonaProps[]>(people);
 
   const picker = useRef<IBasePicker<IPersonaProps>>(null);
 
@@ -150,9 +145,11 @@ export const PeoplePicker: FunctionComponent<IPeoplePickerProps> = (props) => {
   };
 
   const onItemsChange = (items: IPersonaProps[] | undefined): void => {
+    // Check to see if we have an ID for the email address already
     if (items) {
-      setCurrentSelectedItems(items);
       props.updatePeople(items);
+    } else {
+      props.updatePeople([]);
     }
   };
 
@@ -165,7 +162,7 @@ export const PeoplePicker: FunctionComponent<IPeoplePickerProps> = (props) => {
       key={"controlled"}
       selectionAriaLabel={"Selected users"}
       removeButtonAriaLabel={"Remove"}
-      selectedItems={currentSelectedItems}
+      selectedItems={selectedItems}
       onChange={onItemsChange}
       inputProps={{
         "aria-label": props.ariaLabel,

--- a/src/components/PeoplePicker/PeoplePicker.tsx
+++ b/src/components/PeoplePicker/PeoplePicker.tsx
@@ -8,6 +8,7 @@ import {
 import { people } from "@fluentui/example-data";
 import { spWebContext } from "../../providers/SPWebContext";
 import { IPeoplePickerEntity } from "@pnp/sp/profiles";
+import { PrincipalType, PrincipalSource} from "@pnp/sp";
 
 // TODO: Add a way to show as input needed/corrected
 
@@ -75,8 +76,8 @@ export const PeoplePicker: FunctionComponent<IPeoplePickerProps> = (props) => {
             AllowMultipleEntities: false,
             MaximumEntitySuggestions: limitResults ? limitResults : 25,
             QueryString: filterText,
-            PrincipalSource: 15,
-            PrincipalType: 1,
+            PrincipalSource: PrincipalSource.All,
+            PrincipalType: PrincipalType.User,
           });
         let newPersonas: IPersonaProps[] = [];
         results.forEach((person: IPeoplePickerEntity) => {

--- a/src/components/PeoplePicker/PeoplePicker.tsx
+++ b/src/components/PeoplePicker/PeoplePicker.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useState } from "react";
+import { FunctionComponent } from "react";
 import { IPersonaProps } from "@fluentui/react/lib/Persona";
 import { IPerson, Person } from "api/UserApi";
 import {
@@ -8,7 +8,7 @@ import {
 import { people } from "@fluentui/example-data";
 import { spWebContext } from "../../providers/SPWebContext";
 import { IPeoplePickerEntity } from "@pnp/sp/profiles";
-import { PrincipalType, PrincipalSource} from "@pnp/sp";
+import { PrincipalType, PrincipalSource } from "@pnp/sp";
 
 // TODO: Add a way to show as input needed/corrected
 
@@ -42,8 +42,6 @@ export const PeoplePicker: FunctionComponent<IPeoplePickerProps> = (props) => {
   } else {
     selectedItems = [];
   }
-
-  const [peopleList] = useState<IPersonaProps[]>(people);
 
   const onFilterChanged = async (
     filterText: string,
@@ -128,7 +126,7 @@ export const PeoplePicker: FunctionComponent<IPeoplePickerProps> = (props) => {
   };
 
   const filterPersonasByText = (filterText: string): IPersonaProps[] => {
-    return peopleList.filter((item) =>
+    return people.filter((item) =>
       doesTextStartWith(item.text as string, filterText)
     );
   };

--- a/src/components/PeoplePicker/PeoplePicker.tsx
+++ b/src/components/PeoplePicker/PeoplePicker.tsx
@@ -1,8 +1,7 @@
-import { FunctionComponent, useRef, useState } from "react";
+import { FunctionComponent, useState } from "react";
 import { IPersonaProps } from "@fluentui/react/lib/Persona";
 import { IPerson, Person } from "api/UserApi";
 import {
-  IBasePicker,
   IBasePickerSuggestionsProps,
   NormalPeoplePicker,
 } from "@fluentui/react/lib/Pickers";
@@ -44,8 +43,6 @@ export const PeoplePicker: FunctionComponent<IPeoplePickerProps> = (props) => {
   }
 
   const [peopleList] = useState<IPersonaProps[]>(people);
-
-  const picker = useRef<IBasePicker<IPersonaProps>>(null);
 
   const onFilterChanged = async (
     filterText: string,
@@ -167,7 +164,6 @@ export const PeoplePicker: FunctionComponent<IPeoplePickerProps> = (props) => {
       inputProps={{
         "aria-label": props.ariaLabel,
       }}
-      componentRef={picker}
       resolveDelay={300}
       disabled={props.readOnly}
       itemLimit={props.itemLimit ? props.itemLimit : 1}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "isolatedModules": true,
+    "isolatedModules": false,
     "noEmit": true,
     "jsx": "react-jsx"
   },


### PR DESCRIPTION
Updates to the PeoplePicker and Person objects throughout App to use IPerson.
Ensures user when saving to SharePoint if we don't have an ID, and allows clearing Employee GAL entry if initially selected and saved but later cleared and saved again.
Closes #12 
Closes #14 
Closes #16 
Closes #17 
