### PR TITLE
ensure related checklist items are fetched

### DIFF
--- a/src/api/CheckListItemApi.ts
+++ b/src/api/CheckListItemApi.ts
@@ -71,7 +71,7 @@ const transformCheckListItemFromSP = (
   };
 };
 
-const transformCheckListItemsFromSP = (
+export const transformCheckListItemsFromSP = (
   checklistItems: ICheckListResponseItem[]
 ): ICheckListItem[] => {
   return checklistItems.map((item) => {
@@ -83,7 +83,7 @@ const transformCheckListItemsFromSP = (
  * @param RequestId The Id of the Request to retrieve CheckListItems from SharePoint
  * @returns The ICheckListItem for the given Id
  */
-const getCheckListItemsByRequestId = async (RequestId: number) => {
+export const getCheckListItemsByRequestId = async (RequestId: number) => {
   return spWebContext.web.lists
     .getByTitle("CheckListItems")
     .items.filter("RequestId eq " + RequestId)

--- a/src/api/CompleteChecklistItem.ts
+++ b/src/api/CompleteChecklistItem.ts
@@ -1,4 +1,8 @@
-import { ICheckListItem } from "api/CheckListItemApi";
+import {
+  getCheckListItemsByRequestId,
+  ICheckListItem,
+  transformCheckListItemsFromSP,
+} from "api/CheckListItemApi";
 import { spWebContext } from "providers/SPWebContext";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { DateTime } from "luxon";
@@ -46,11 +50,8 @@ const completeCheckListItem = (
 
 export const useCompleteChecklistItem = (item: ICheckListItem) => {
   const queryClient = useQueryClient();
-  const checklistItems = queryClient.getQueryData<ICheckListItem[]>([
-    "checklist",
-    item.RequestId,
-  ]);
   const currentUser = useCurrentUser();
+  let checklistItems: ICheckListItem[];
 
   return useMutation(
     ["checklist", item.Id],
@@ -58,6 +59,13 @@ export const useCompleteChecklistItem = (item: ICheckListItem) => {
       return completeCheckListItem(item, checklistItems, currentUser);
     },
     {
+      onMutate: async () => {
+        const checklistItemsTemp = await queryClient.fetchQuery(
+          ["checklist", item.RequestId, "noSelect"],
+          () => getCheckListItemsByRequestId(item.RequestId)
+        );
+        checklistItems = transformCheckListItemsFromSP(checklistItemsTemp);
+      },
       onSuccess: () => {
         return queryClient.invalidateQueries(["checklist"]);
       },

--- a/src/api/CompleteChecklistItem.ts
+++ b/src/api/CompleteChecklistItem.ts
@@ -61,7 +61,7 @@ export const useCompleteChecklistItem = (item: ICheckListItem) => {
     {
       onMutate: async () => {
         const checklistItemsTemp = await queryClient.fetchQuery(
-          ["checklist", item.RequestId, "noSelect"],
+          ["checklist", item.RequestId],
           () => getCheckListItemsByRequestId(item.RequestId)
         );
         checklistItems = transformCheckListItemsFromSP(checklistItemsTemp);


### PR DESCRIPTION
Fixed MyCheckListItems page not activating related checkListItems (due to query cache miss).

Simple fix, but now I'm thinking I should have done the fetch for the checkListItems in the completeCheckListItem function rather than in the onMutate of the useCompleteChecklistItem hook.

I had to export a couple of functions from the plain Api file that we don't really want to. I almost merged these two files into the plain Api file to eliminate the exports, but wanted to give you a clear changelog. Happy to still do so. Let me know what you think and I'll update this PR.

Build is in the robForReview folder.