### PR TITLE
Fix empName being set on Supervisor GAL selection

### DIFF
--- a/src/components/InRequest/InRequestNewForm.tsx
+++ b/src/components/InRequest/InRequestNewForm.tsx
@@ -548,10 +548,8 @@ export const InRequestNewForm = () => {
               selectedItems={value}
               updatePeople={(items) => {
                 if (items?.[0]) {
-                  setValue("empName", items[0].text);
                   onChange(items[0]);
                 } else {
-                  setValue("empName", "");
                   onChange([]);
                 }
               }}


### PR DESCRIPTION
Fix issue @RobertPorterfield found on creation of a new request, and selecting a different superviosr than the one set as default.