### PR TITLE
Add User Impersonation

### DIFF
--- a/src/api/CheckListItemApi.ts
+++ b/src/api/CheckListItemApi.ts
@@ -99,7 +99,8 @@ const getOpenCheckListItems = async () => {
     .getByTitle("CheckListItems")
     .items.filter("CompletedDate eq null")
     .select(requestedFields)
-    .expand(expandedFields)();
+    .expand(expandedFields)
+    .top(5000)();
 };
 
 /**

--- a/src/api/CompleteChecklistItem.ts
+++ b/src/api/CompleteChecklistItem.ts
@@ -6,10 +6,12 @@ import {
 import { spWebContext } from "providers/SPWebContext";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { DateTime } from "luxon";
-import { Person, useCurrentUser } from "api/UserApi";
+import { Person } from "api/UserApi";
 import { templates } from "api/CreateChecklistItems";
 import { useEmail } from "hooks/useEmail";
 import { RoleType } from "api/RolesApi";
+import { useContext } from "react";
+import { UserContext } from "providers/UserProvider";
 
 const completeCheckListItem = (
   item: ICheckListItem,
@@ -178,7 +180,7 @@ const completeCheckListItem = (
 
 export const useCompleteChecklistItem = (item: ICheckListItem) => {
   const queryClient = useQueryClient();
-  const currentUser = useCurrentUser();
+  const currentUser = useContext(UserContext).user;
   const email = useEmail();
   let checklistItems: ICheckListItem[];
 

--- a/src/api/InternalErrors.tsx
+++ b/src/api/InternalErrors.tsx
@@ -15,21 +15,6 @@ export class InternalError implements Error {
   }
 }
 
-export class ApiError extends InternalError {
-  name: string = "ApiError";
-
-  constructor(e?: Error, message?: string) {
-    super(
-      e,
-      message
-        ? message
-        : e
-        ? e.message
-        : "An unknown error occurred while communicating with SharePoint!"
-    );
-  }
-}
-
 export class EmailError extends InternalError {
   name: string = "EmailError";
 

--- a/src/api/RequestApi.ts
+++ b/src/api/RequestApi.ts
@@ -150,7 +150,8 @@ const getRequests = async () => {
   return spWebContext.web.lists
     .getByTitle("Items")
     .items.select(requestedFields)
-    .expand(expandedFields)();
+    .expand(expandedFields)
+    .top(5000)();
 };
 
 // Exported hooks for working with requests

--- a/src/api/RequestApi.ts
+++ b/src/api/RequestApi.ts
@@ -159,7 +159,7 @@ const getRequests = async () => {
 export const useMyRequests = () => {
   const userId = useContext(UserContext).user.Id;
   return useQuery({
-    queryKey: ["requests", userId],
+    queryKey: ["requests", "user" + userId],
     queryFn: () => getMyRequests(userId),
     select: transformInRequestsFromSP,
   });

--- a/src/api/RequestApi.ts
+++ b/src/api/RequestApi.ts
@@ -3,8 +3,8 @@ import { worklocation } from "constants/WorkLocations";
 import { IPerson, Person } from "api/UserApi";
 import { spWebContext } from "providers/SPWebContext";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-
-declare var _spPageContextInfo: any;
+import { UserContext } from "providers/UserProvider";
+import { useContext } from "react";
 
 /**
  * Directly map the incoming request to the IResponseItem to perform type
@@ -128,20 +128,14 @@ const requestedFields =
 const expandedFields = "supGovLead,employee";
 
 // Internal functions that actually do the fetching
-const getMyRequests = async () => {
-  const userId =
-    process.env.NODE_ENV === "development" ? 1 : _spPageContextInfo?.userId;
-  if (userId === undefined) {
-    return Promise.reject([]);
-  } else {
-    return spWebContext.web.lists
-      .getByTitle("Items")
-      .items.filter(
-        `(supGovLead/Id eq '${userId}' or employee/Id eq '${userId}') and closedOrCancelledDate eq null`
-      )
-      .select(requestedFields)
-      .expand(expandedFields)();
-  }
+const getMyRequests = async (userId: number) => {
+  return spWebContext.web.lists
+    .getByTitle("Items")
+    .items.filter(
+      `(supGovLead/Id eq '${userId}' or employee/Id eq '${userId}') and closedOrCancelledDate eq null`
+    )
+    .select(requestedFields)
+    .expand(expandedFields)();
 };
 
 export const getRequest = async (Id: number) => {
@@ -162,7 +156,10 @@ const getRequests = async () => {
 // Exported hooks for working with requests
 
 export const useMyRequests = () => {
-  return useQuery(["requests", "currentUser"], getMyRequests, {
+  const userId = useContext(UserContext).user.Id;
+  return useQuery({
+    queryKey: ["requests", userId],
+    queryFn: () => getMyRequests(userId),
     select: transformInRequestsFromSP,
   });
 };

--- a/src/api/RolesApi.ts
+++ b/src/api/RolesApi.ts
@@ -6,9 +6,11 @@ import {
   UseQueryResult,
 } from "@tanstack/react-query";
 import { spWebContext } from "providers/SPWebContext";
-import { IPerson, useCurrentUser } from "api/UserApi";
+import { IPerson } from "api/UserApi";
 import { IItemAddResult } from "@pnp/sp/items";
 import { useError } from "hooks/useError";
+import { useContext } from "react";
+import { UserContext } from "providers/UserProvider";
 
 /** Enum used to define the different roles in the tool */
 export enum RoleType {
@@ -167,7 +169,7 @@ const getRolesForUser = async (userId?: number): Promise<SPRole[]> => {
  */
 export const useUserRoles = (userId?: number) => {
   const errObj = useError();
-  const currentUser = useCurrentUser();
+  const currentUser = useContext(UserContext).user;
 
   if (!userId) {
     userId = currentUser.Id;

--- a/src/api/UserApi.ts
+++ b/src/api/UserApi.ts
@@ -1,12 +1,5 @@
 import { IPersonaProps } from "@fluentui/react";
-import { spWebContext } from "providers/SPWebContext";
-import { ApiError } from "api/InternalErrors";
 import { TestImages } from "@fluentui/example-data";
-import "@pnp/sp/webs";
-import "@pnp/sp/lists";
-import "@pnp/sp/items";
-import "@pnp/sp/batching";
-import "@pnp/sp/site-users/web";
 
 declare var _spPageContextInfo: any;
 
@@ -74,46 +67,3 @@ export const useCurrentUser = () => {
 
   return currentUser;
 };
-
-export interface IUserApi {
-  /**
-   * Get the Id of the user with the email given
-   *
-   * @param email The email of the user
-   *
-   * @returns The Id of the user with the supplied email
-   */
-  getUserId: (email: string) => Promise<number>;
-}
-
-export class UserApi implements IUserApi {
-  private currentUser?: IPerson;
-
-  getUserId = async (email: string) => {
-    try {
-      return email ? (await spWebContext.web.ensureUser(email)).data.Id : -1;
-    } catch (e) {
-      console.error(
-        `Error occurred while trying to fetch user with Email ${email}`
-      );
-      console.error(e);
-      if (e instanceof Error) {
-        throw new ApiError(
-          e,
-          `Error occurred while trying to fetch user with Email ${email}: ${e.message}`
-        );
-      } else if (typeof e === "string") {
-        throw new ApiError(
-          new Error(
-            `Error occurred while trying to fetch user with Email ${email}: ${e}`
-          )
-        );
-      } else {
-        throw new ApiError(
-          undefined,
-          `Unknown error occurred while trying to fetch user with Email ${email}`
-        );
-      }
-    }
-  };
-}

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -12,6 +12,7 @@ import { Link } from "react-router-dom";
 import { UserContext } from "providers/UserProvider";
 import { tokens } from "@fluentui/react-theme";
 import { RoleType } from "api/RolesApi";
+import { ImpersonationForm } from "components/AppHeader/ImpersonationForm";
 
 /* FluentUI Styling */
 const useStyles = makeStyles({
@@ -76,7 +77,7 @@ export const AppHeader: FunctionComponent<any> = (props) => {
             </Link>
           )
         }
-        <Popover>
+        <Popover trapFocus={true} closeOnScroll={true} withArrow={true}>
           <PopoverTrigger>
             <Tooltip
               relationship="description"
@@ -96,6 +97,13 @@ export const AppHeader: FunctionComponent<any> = (props) => {
                 <li key={role}>{role}</li>
               ))}
             </ul>
+            {
+              //Only load the Impersonation Form if we are in NodeJS or a TEST environment
+              (process.env.NODE_ENV === "development" ||
+                process.env.REACT_APP_TEST_SYS === "true") && (
+                <ImpersonationForm></ImpersonationForm>
+              )
+            }
           </PopoverSurface>
         </Popover>
       </div>

--- a/src/components/AppHeader/ImpersonationForm.tsx
+++ b/src/components/AppHeader/ImpersonationForm.tsx
@@ -1,0 +1,151 @@
+import {
+  Text,
+  makeStyles,
+  Button,
+  FluentProvider,
+} from "@fluentui/react-components";
+import { useContext, FunctionComponent } from "react";
+import { UserContext } from "providers/UserProvider";
+import { tokens } from "@fluentui/react-theme";
+import { Dialog, DialogFooter, DialogType } from "@fluentui/react";
+import { useBoolean } from "@fluentui/react-hooks";
+import { Controller, useForm } from "react-hook-form";
+import { PeoplePicker } from "components/PeoplePicker/PeoplePicker";
+import { spWebContext } from "providers/SPWebContext";
+import { Person } from "api/UserApi";
+
+// TODO - Investigate why the Popover showing roles doesn't disappear when Dialog opens
+
+/* FluentUI Styling */
+const useStyles = makeStyles({
+  errorText: {
+    color: tokens.colorPaletteRedForeground1,
+    fontSize: tokens.fontSizeBase200,
+    display: "block",
+  },
+});
+
+/** React Hook Form (RHF) values */
+interface IImpersonateForm {
+  /** The user object returned by RHF */ user: Person;
+}
+/** Component that displays a button to enable Impersonation
+ *  Upon clicking, it prompts the user to select the appropriate impersonation action
+ *  This component is only used in Development and when REACT_APP_TEST_SYS flag is set to "true"
+ */
+export const ImpersonationForm: FunctionComponent<any> = (props) => {
+  const classes = useStyles();
+  const userContext = useContext(UserContext);
+
+  /* Show the Impersonate Dialog or not */
+  const [
+    isImpersonateDialogOpen,
+    { setTrue: showImpersonateDialog, setFalse: hideImpersonateDialog },
+  ] = useBoolean(false);
+
+  /* React Hook Form for the Impersonation Dialog box */
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<IImpersonateForm>();
+
+  /**
+   * Take the form data (or no data) and if it was provided, then pass to the UserContext to update
+   * If it was not provided, then pass nothing to UserContext, so it resets to self
+   *
+   * @param data The RHF data, or undefined
+   * @returns a void Promise
+   */
+  const performImpersonate = async (data: IImpersonateForm | undefined) => {
+    if (data) {
+      // Lookup the userId
+      const userId = (await spWebContext.web.ensureUser(data.user.EMail)).data
+        .Id;
+      // Create a new userData object, to pass to the impersonation function
+      const userData = { ...data.user, Id: userId };
+      userContext.impersonate(userData);
+      hideImpersonateDialog(); // Close the impersonation dialog
+    }
+  };
+
+  /**
+   * Take the form data (or no data) and if it was provided, then pass to the UserContext to update
+   * If it was not provided, then pass nothing to UserContext, so it resets to self
+   *
+   * @param data The RHF data, or undefined
+   */
+  const removeImpersonation = () => {
+    // Call the UserContext impersonate function with no defined data to remove the impersonation
+    userContext.impersonate(undefined);
+    hideImpersonateDialog(); // Close the impersonation dialog
+  };
+
+  return (
+    <>
+      <Button appearance="primary" onClick={showImpersonateDialog}>
+        Impersonate User
+      </Button>
+      <Dialog
+        hidden={!isImpersonateDialogOpen}
+        modalProps={{
+          isBlocking: true,
+        }}
+        minWidth="500px"
+        onDismiss={hideImpersonateDialog}
+        dialogContentProps={{
+          type: DialogType.close,
+          title: "Select user to impersonate",
+        }}
+      >
+        <FluentProvider>
+          <form
+            id="impersonateForm"
+            onSubmit={handleSubmit(performImpersonate)}
+          >
+            <div>
+              <Controller
+                name="user"
+                control={control}
+                rules={{
+                  required:
+                    "You must select a user if you want to impersonate someone",
+                }}
+                render={({ field: { onChange, value } }) => (
+                  <PeoplePicker
+                    ariaLabel="User to Impersonate"
+                    aria-describedby="userErr"
+                    selectedItems={value}
+                    updatePeople={(items) => {
+                      if (items?.[0]) {
+                        onChange(items[0]);
+                      } else {
+                        onChange([]);
+                      }
+                    }}
+                  />
+                )}
+              />
+              {errors.user && (
+                <Text id="userErr" className={classes.errorText}>
+                  {errors.user.message}
+                </Text>
+              )}
+            </div>
+            <DialogFooter>
+              <Button appearance="primary" type="submit">
+                Impersonate
+              </Button>
+              <Button appearance="primary" onClick={removeImpersonation}>
+                Return as myself
+              </Button>
+              <Button appearance="secondary" onClick={hideImpersonateDialog}>
+                Cancel
+              </Button>
+            </DialogFooter>
+          </form>
+        </FluentProvider>
+      </Dialog>
+    </>
+  );
+};

--- a/src/components/InRequest/InRequestNewForm.tsx
+++ b/src/components/InRequest/InRequestNewForm.tsx
@@ -1,5 +1,5 @@
 import { ComboBox, DatePicker, IComboBoxOption } from "@fluentui/react";
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
 import { PeoplePicker } from "components/PeoplePicker/PeoplePicker";
 import { OFFICES } from "constants/Offices";
 import { GS_GRADES, NH_GRADES, MIL_GRADES } from "constants/GradeRanks";
@@ -15,7 +15,6 @@ import {
   RadioGroup,
   tokens,
 } from "@fluentui/react-components";
-import { useCurrentUser } from "api/UserApi";
 import { IInRequest, useAddRequest } from "api/RequestApi";
 import { useAddTasks } from "api/CreateChecklistItems";
 import { useForm, Controller } from "react-hook-form";
@@ -29,6 +28,7 @@ import {
   ContactIcon,
 } from "@fluentui/react-icons-mdl2";
 import { ToggleLeftRegular, RadioButtonFilled } from "@fluentui/react-icons";
+import { UserContext } from "providers/UserProvider";
 
 /* FluentUI Styling */
 const useStyles = makeStyles({
@@ -71,7 +71,7 @@ const useStyles = makeStyles({
 
 export const InRequestNewForm = () => {
   const classes = useStyles();
-  const currentUser = useCurrentUser();
+  const currentUser = useContext(UserContext).user;
   const email = useEmail();
   const addRequest = useAddRequest();
   const addTasks = useAddTasks();

--- a/src/components/Roles/Roles.tsx
+++ b/src/components/Roles/Roles.tsx
@@ -1,11 +1,10 @@
-import { useMemo, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import {
   RoleType,
   SPRole,
   useAllUserRolesByRole,
   useAllUserRolesByUser,
   useRoleManagement,
-  useUserRoles,
 } from "api/RolesApi";
 import { makeStyles } from "@fluentui/react-components";
 import { Navigate } from "react-router-dom";
@@ -21,6 +20,7 @@ import {
 } from "@fluentui/react";
 import { useBoolean } from "@fluentui/react-hooks";
 import { AddUserRolePanel } from "components/Roles/AddUserRolePanel";
+import { UserContext } from "providers/UserProvider";
 
 /** FluentUI Styling */
 const useStyles = makeStyles({
@@ -46,7 +46,7 @@ export const Roles: React.FunctionComponent = () => {
   const { removeRole } = useRoleManagement();
 
   // Get the role of the current user
-  const userRoles = useUserRoles();
+  const userRoles = useContext(UserContext).roles;
 
   // Selected items in the DetailsList
   const [selectedItems, setSelectedItems] = useState<IObjectWithKey[]>([]);
@@ -175,11 +175,11 @@ export const Roles: React.FunctionComponent = () => {
   ];
 
   // Ensure we have a roles object before determining whether or not to redirect
-  if (!userRoles.isFetched) {
+  if (!userRoles) {
     return <>Loading...</>;
   }
 
-  if (!userRoles.data?.includes(RoleType.ADMIN)) {
+  if (!userRoles.includes(RoleType.ADMIN)) {
     // If they are not an ADMIN, redirect to the Homepage
     return <Navigate to="/" replace={true} />;
   }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -309,8 +309,12 @@ export const handlers = [
               ...(item.CompletedById && {
                 CompletedBy: {
                   Id: item.CompletedById,
-                  Title: "Default User " + item.CompletedById,
-                  EMail: "defaultTEST@us.af.mil",
+                  Title: testUsers.find(
+                    (user) => user.Id === item.CompletedById
+                  )?.Title,
+                  EMail: testUsers.find(
+                    (user) => user.Id === item.CompletedById
+                  )?.EMail,
                 },
               }),
               ...(item.Active && { Active: true }),

--- a/src/providers/SPWebContext.ts
+++ b/src/providers/SPWebContext.ts
@@ -4,9 +4,7 @@ import "@pnp/sp/lists/web";
 import "@pnp/sp/items/list";
 import "@pnp/sp/site-users/web";
 import "@pnp/sp/profiles";
-
-// Possible future import
-//import "@pnp/sp/batching";
+import "@pnp/sp/batching";
 
 declare var _spPageContextInfo: any;
 

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -1,15 +1,18 @@
 import { createContext, FunctionComponent } from "react";
 import { RoleType, useUserRoles } from "api/RolesApi";
-import { IPerson, useCurrentUser } from "api/UserApi";
+import { Person, useCurrentUser } from "api/UserApi";
 
 export interface IUserContext {
-  user: IPerson | undefined;
-  roles: RoleType[];
+  user: Person;
+  roles?: RoleType[];
 }
 
-export const UserContext = createContext<Partial<IUserContext>>({
-  user: undefined,
-});
+export const UserContext = createContext({
+  // This value would ONLY be used if a component tried referencing it, and there was no Provider for that context above it.
+  // By defining a user here, we help Typescript with it's typechecking
+  user: new Person({ Id: 0, Title: "Placeholder", EMail: "Placeholder" }),
+  roles: undefined,
+} as IUserContext);
 
 export const UserProvider: FunctionComponent = ({ children }) => {
   const user = useCurrentUser();
@@ -17,7 +20,7 @@ export const UserProvider: FunctionComponent = ({ children }) => {
 
   const userContext: IUserContext = {
     user,
-    roles: roles ? roles : ([] as RoleType[]),
+    roles: roles ? roles : undefined,
   };
 
   return (

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -1,31 +1,58 @@
-import { createContext, FunctionComponent } from "react";
+import { createContext, FunctionComponent, useState } from "react";
 import { RoleType, useUserRoles } from "api/RolesApi";
 import { Person, useCurrentUser } from "api/UserApi";
 
-export interface IUserContext {
-  user: Person;
-  roles?: RoleType[];
+interface IUserContext {
+  /** Current or Impersonated User object */ user: Person;
+  /** Current or Impersonated Roles object */ roles?: RoleType[];
+  /** Function to update to impersonate, or resume as logged in */
+  impersonate: (user?: Person) => void;
 }
-
+/** The UserContext object
+ * Provides the logged in user and roles objects, or if impersonating, the info for the user/roles being impersonated
+ * Also provides an impersonate function to update
+ */
 export const UserContext = createContext({
   // This value would ONLY be used if a component tried referencing it, and there was no Provider for that context above it.
-  // By defining a user here, we help Typescript with it's typechecking
+  // We use thie Context.Provider at a high level object in the tree, so it should never be referenced as undefined
   user: new Person({ Id: 0, Title: "Placeholder", EMail: "Placeholder" }),
   roles: undefined,
+  impersonate: (user) => {},
 } as IUserContext);
 
 export const UserProvider: FunctionComponent = ({ children }) => {
-  const user = useCurrentUser();
+  // Get the current logged in user
+  const loggedInUser = useCurrentUser();
+  const [user, setUser] = useState(loggedInUser);
+  /* We have to pass in a user id for two reasons:
+      1)  This will take care of when we are impersonating, so that it will pull the roles for that user
+      2)  Because this compenent IS the component that will be the Provider for the UserContext context, if we called
+            useUserRoles() without a userId, it would try to get the context, and would load the default context, which
+            is just a placeholder 
+   */
   const { data: roles } = useUserRoles(user.Id);
 
+  /**
+   * Turn on/off or change the impersonated user
+   *
+   * @param user - Optional - If passed will impersonate that user, if not passed, will revert to being logged in user
+   */
+  const impersonate = (user?: Person) => {
+    if (user) {
+      setUser(user);
+    } else {
+      setUser(loggedInUser);
+    }
+  };
+
+  /** The object to be passed to the Provider for all Consumers to use */
   const userContext: IUserContext = {
     user,
     roles: roles ? roles : undefined,
+    impersonate: impersonate,
   };
 
   return (
     <UserContext.Provider value={userContext}>{children}</UserContext.Provider>
   );
 };
-
-export const { Consumer } = UserContext;


### PR DESCRIPTION
Updated to add User Impersonation ability within Dev and Test, which required converting direct user calls to use the UserContext instead
Removed unused UserApi class and ApiError class 
Updated the mocks to set Checklist Item completed user info correctly rather than as Default User [Id]
Update to pull up to 5k items instead of 100 for some queries 

Add indexes for Checklist Items
1) RequestId
2) CompletedDate

Add indexes for Roles
1) User

Add indexes for Requests
1) supGovLead
2) employeeId
3) closedOrCancelledDate