### PR TITLE
Show Prerequisites on Inactive task detail panel

### DIFF
--- a/src/api/CompleteChecklistItem.ts
+++ b/src/api/CompleteChecklistItem.ts
@@ -13,6 +13,126 @@ import { RoleType } from "api/RolesApi";
 import { useContext } from "react";
 import { UserContext } from "providers/UserProvider";
 
+/** The list of tasks and their prerequisite tasks */
+export const templatePreqs = [
+  //  WelcomePackage -- No Prerequisites
+  //  IA_Training -- No Prerequisites
+  {
+    templId: templates.ObtainCACGov,
+    preReqs: [templates.InstallationInProcess],
+  },
+  //  ObtainCACCtr -- No Prerequisites
+  //  InstallationInProcess -- No Prerequisites
+  //  GTC -- No Prerequisites
+  {
+    templId: templates.DTS,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.ATAAPS,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.VerifyMyLearn,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.VerifyMyETMS,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.MandatoryTraining,
+    preReqs: [templates.VerifyMyETMS, templates.VerifyMyLearn],
+  },
+  {
+    templId: templates.PhoneSetup,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.OrientationVideos,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.Bookmarks,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.NewcomerBrief,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  //  SupervisorTraining -- No Prerequisites
+  {
+    templId: templates.ConfirmMandatoryTraining,
+    preReqs: [templates.MandatoryTraining],
+  },
+  {
+    templId: templates.ConfirmMyLearn,
+    preReqs: [templates.VerifyMyLearn],
+  },
+  {
+    templId: templates.ConfirmMyETMS,
+    preReqs: [templates.VerifyMyETMS],
+  },
+  //  UnitOrientation -- No Prerequisites
+  //  Brief971Folder -- No Prerequisites
+  {
+    templId: templates.SignedPerformContribPlan,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.SignedTeleworkAgreement,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.TeleworkAddedToWHAT,
+    preReqs: [templates.SignedTeleworkAgreement],
+  },
+  {
+    templId: templates.SupervisorCoord2875,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.SecurityCoord2875,
+    preReqs: [templates.SupervisorCoord2875],
+  },
+  {
+    templId: templates.ProvisionAFNET,
+    preReqs: [templates.SecurityCoord2875],
+  },
+  {
+    templId: templates.EquipmentIssue,
+    preReqs: [templates.SecurityCoord2875],
+  },
+  {
+    templId: templates.AddSecurityGroups,
+    preReqs: [templates.ProvisionAFNET],
+  },
+  {
+    templId: templates.BuildingAccess,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.VerifyDirectDeposit,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.VerifyTaxStatus,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    templId: templates.SecurityTraining,
+    preReqs: [templates.ProvisionAFNET],
+  },
+  {
+    templId: templates.ConfirmSecurityTraining,
+    preReqs: [templates.SecurityTraining],
+  },
+  {
+    templId: templates.SecurityRequirements,
+    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+];
+
 const completeCheckListItem = (
   item: ICheckListItem,
   checklistItems: ICheckListItem[],
@@ -43,145 +163,30 @@ const completeCheckListItem = (
     CompletedDate: DateTime.now().toISODate(),
   });
 
-  // Find additional updates
-  switch (item.TemplateId) {
-    case templates.ObtainCACGov:
-    case templates.ObtainCACCtr:
-      //Activate several tasks if we are completing one of the 2 different CAC tasks
-      checklistItems?.forEach((element) => {
-        if (
-          element.TemplateId === templates.VerifyMyLearn ||
-          element.TemplateId === templates.VerifyMyETMS ||
-          element.TemplateId === templates.PhoneSetup ||
-          element.TemplateId === templates.OrientationVideos ||
-          element.TemplateId === templates.Bookmarks ||
-          element.TemplateId === templates.NewcomerBrief ||
-          element.TemplateId === templates.SignedPerformContribPlan ||
-          element.TemplateId === templates.SignedTeleworkAgreement ||
-          element.TemplateId === templates.SupervisorCoord2875 ||
-          element.TemplateId === templates.BuildingAccess ||
-          element.TemplateId === templates.VerifyDirectDeposit ||
-          element.TemplateId === templates.VerifyTaxStatus ||
-          element.TemplateId === templates.DTS ||
-          element.TemplateId === templates.ATAAPS ||
-          element.TemplateId === templates.SecurityRequirements
-        ) {
-          addChecklistItemActivated(element);
-        }
-      });
-      break;
-    case templates.VerifyMyETMS:
-      // Activate the Confirm AFMC myETMS account task
-      checklistItems?.forEach((element) => {
-        if (element.TemplateId === templates.ConfirmMyETMS) {
-          addChecklistItemActivated(element);
-        }
-      });
+  // Locate those items that have this item as a prereq
+  const preqs = templatePreqs.filter((templ) =>
+    templ.preReqs.includes(item.TemplateId)
+  );
 
-      // Determine if this checklist item has a Verify Air Force myLearning account task
-      //   if it does, then only activate Mandatory Training task if it is completed
-      let myLearnTask = checklistItems?.find(
-        (item) => item.TemplateId === templates.VerifyMyLearn
+  // If we found some, examine each to see if we met all the prereqs for that item
+  preqs.forEach((rule) => {
+    const needCompleting = checklistItems.filter(
+      (item2) =>
+        item.TemplateId !== item2.TemplateId && // Ensure we aren't looking at the item we just completed
+        rule.preReqs.includes(item2.TemplateId) && // Is this item part of the prereqs for this particular item to become active
+        !item2.CompletedBy // If it is, and it isn't completed, then flag we have an item that still needs completed for this item
+    );
+
+    // If this item has no more more prereqs, then add it to the list to become activated
+    if (needCompleting.length === 0) {
+      const item = checklistItems.find(
+        (item) => rule.templId === item.TemplateId
       );
-      if (myLearnTask?.CompletedBy) {
-        checklistItems?.forEach((element) => {
-          if (element.TemplateId === templates.MandatoryTraining) {
-            addChecklistItemActivated(element);
-          }
-        });
+      if (item) {
+        addChecklistItemActivated(item);
       }
-      break;
-    case templates.VerifyMyLearn:
-      checklistItems?.forEach((element) => {
-        if (element.TemplateId === templates.ConfirmMyLearn) {
-          addChecklistItemActivated(element);
-        }
-      });
-      let myETMSTask = checklistItems?.find(
-        (item) => item.TemplateId === templates.VerifyMyETMS
-      );
-      if (myETMSTask) {
-        if (myETMSTask.CompletedBy) {
-          checklistItems?.forEach((element) => {
-            if (element.TemplateId === templates.MandatoryTraining) {
-              addChecklistItemActivated(element);
-            }
-          });
-        }
-      } // If we can't find the myETMS task, it is because it wasn't required (ex CTR), so it is safe to activate the mandatory training
-      else {
-        checklistItems?.forEach((element) => {
-          if (element.TemplateId === templates.MandatoryTraining) {
-            addChecklistItemActivated(element);
-          }
-        });
-      }
-      break;
-    case templates.InstallationInProcess:
-      //Activate the Obtain CAC (Mil/Civ) task
-      checklistItems?.forEach((element) => {
-        if (element.TemplateId === templates.ObtainCACGov) {
-          addChecklistItemActivated(element);
-        }
-      });
-      break;
-    case templates.MandatoryTraining:
-      //Activate the Confirm mandatory training task
-      checklistItems?.forEach((element) => {
-        if (element.TemplateId === templates.ConfirmMandatoryTraining) {
-          addChecklistItemActivated(element);
-        }
-      });
-      break;
-    case templates.SignedTeleworkAgreement:
-      //Activate the Telework status entered in WHAT task
-      checklistItems?.forEach((element) => {
-        if (element.TemplateId === templates.TeleworkAddedToWHAT) {
-          addChecklistItemActivated(element);
-        }
-      });
-      break;
-    case templates.SupervisorCoord2875:
-      //Activate the Security Coordination of 2875 task
-      checklistItems?.forEach((element) => {
-        if (element.TemplateId === templates.SecurityCoord2875) {
-          addChecklistItemActivated(element);
-        }
-      });
-      break;
-    case templates.SecurityCoord2875:
-      //Activate the Provision/move AFNET account and Equipment Issue tasks
-      checklistItems?.forEach((element) => {
-        if (
-          element.TemplateId === templates.ProvisionAFNET ||
-          element.TemplateId === templates.EquipmentIssue
-        ) {
-          addChecklistItemActivated(element);
-        }
-      });
-      break;
-    case templates.ProvisionAFNET:
-      //Activate the Add to security groups and Complete security training tasks
-      checklistItems?.forEach((element) => {
-        if (
-          element.TemplateId === templates.AddSecurityGroups ||
-          element.TemplateId === templates.SecurityTraining
-        ) {
-          addChecklistItemActivated(element);
-        }
-      });
-      break;
-    case templates.SecurityTraining:
-      //Activate the Confirm security training complete task
-      checklistItems?.forEach((element) => {
-        if (element.TemplateId === templates.ConfirmSecurityTraining) {
-          addChecklistItemActivated(element);
-        }
-      });
-      break;
-    default:
-      break;
-  }
+    }
+  });
 
   // If we activated any checklist items, then send out appropriate notifications
   if (activatedTasksByRole.size > 0) {

--- a/src/api/CompleteChecklistItem.ts
+++ b/src/api/CompleteChecklistItem.ts
@@ -7,131 +7,11 @@ import { spWebContext } from "providers/SPWebContext";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { DateTime } from "luxon";
 import { Person } from "api/UserApi";
-import { templates } from "api/CreateChecklistItems";
+import { checklistTemplates } from "api/CreateChecklistItems";
 import { useEmail } from "hooks/useEmail";
 import { RoleType } from "api/RolesApi";
 import { useContext } from "react";
 import { UserContext } from "providers/UserProvider";
-
-/** The list of tasks and their prerequisite tasks */
-export const templatePreqs = [
-  //  WelcomePackage -- No Prerequisites
-  //  IA_Training -- No Prerequisites
-  {
-    templId: templates.ObtainCACGov,
-    preReqs: [templates.InstallationInProcess],
-  },
-  //  ObtainCACCtr -- No Prerequisites
-  //  InstallationInProcess -- No Prerequisites
-  //  GTC -- No Prerequisites
-  {
-    templId: templates.DTS,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.ATAAPS,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.VerifyMyLearn,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.VerifyMyETMS,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.MandatoryTraining,
-    preReqs: [templates.VerifyMyETMS, templates.VerifyMyLearn],
-  },
-  {
-    templId: templates.PhoneSetup,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.OrientationVideos,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.Bookmarks,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.NewcomerBrief,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  //  SupervisorTraining -- No Prerequisites
-  {
-    templId: templates.ConfirmMandatoryTraining,
-    preReqs: [templates.MandatoryTraining],
-  },
-  {
-    templId: templates.ConfirmMyLearn,
-    preReqs: [templates.VerifyMyLearn],
-  },
-  {
-    templId: templates.ConfirmMyETMS,
-    preReqs: [templates.VerifyMyETMS],
-  },
-  //  UnitOrientation -- No Prerequisites
-  //  Brief971Folder -- No Prerequisites
-  {
-    templId: templates.SignedPerformContribPlan,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.SignedTeleworkAgreement,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.TeleworkAddedToWHAT,
-    preReqs: [templates.SignedTeleworkAgreement],
-  },
-  {
-    templId: templates.SupervisorCoord2875,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.SecurityCoord2875,
-    preReqs: [templates.SupervisorCoord2875],
-  },
-  {
-    templId: templates.ProvisionAFNET,
-    preReqs: [templates.SecurityCoord2875],
-  },
-  {
-    templId: templates.EquipmentIssue,
-    preReqs: [templates.SecurityCoord2875],
-  },
-  {
-    templId: templates.AddSecurityGroups,
-    preReqs: [templates.ProvisionAFNET],
-  },
-  {
-    templId: templates.BuildingAccess,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.VerifyDirectDeposit,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.VerifyTaxStatus,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
-    templId: templates.SecurityTraining,
-    preReqs: [templates.ProvisionAFNET],
-  },
-  {
-    templId: templates.ConfirmSecurityTraining,
-    preReqs: [templates.SecurityTraining],
-  },
-  {
-    templId: templates.SecurityRequirements,
-    preReqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-];
 
 const completeCheckListItem = (
   item: ICheckListItem,
@@ -164,8 +44,8 @@ const completeCheckListItem = (
   });
 
   // Locate those items that have this item as a prereq
-  const preqs = templatePreqs.filter((templ) =>
-    templ.preReqs.includes(item.TemplateId)
+  const preqs = checklistTemplates.filter((templ) =>
+    templ.Prereqs.includes(item.TemplateId)
   );
 
   // If we found some, examine each to see if we met all the prereqs for that item
@@ -173,14 +53,14 @@ const completeCheckListItem = (
     const needCompleting = checklistItems.filter(
       (item2) =>
         item.TemplateId !== item2.TemplateId && // Ensure we aren't looking at the item we just completed
-        rule.preReqs.includes(item2.TemplateId) && // Is this item part of the prereqs for this particular item to become active
+        rule.Prereqs.includes(item2.TemplateId) && // Is this item part of the prereqs for this particular item to become active
         !item2.CompletedBy // If it is, and it isn't completed, then flag we have an item that still needs completed for this item
     );
 
     // If this item has no more more prereqs, then add it to the list to become activated
     if (needCompleting.length === 0) {
       const item = checklistItems.find(
-        (item) => rule.templId === item.TemplateId
+        (item) => rule.TemplateId === item.TemplateId
       );
       if (item) {
         addChecklistItemActivated(item);

--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { RoleType } from "api/RolesApi";
 import { ICheckListItem } from "./CheckListItemApi";
 
-export enum templates {
+enum templates {
   WelcomePackage = 1,
   IA_Training = 2,
   ObtainCACGov = 3,
@@ -43,58 +43,41 @@ export enum templates {
   SecurityRequirements = 35,
 }
 
-const createInboundChecklistItems = (request: IInRequest) => {
-  const [batchedSP, execute] = spWebContext.batched();
+// Active is a derived prop based on if there are Prereqs or not
+// RequestId will be added when the template is used to create an item
+// Id is not needed b/c SharePoint will assign one
+// We add Prereqs as a required entry containing the Prequiste TemplateId(s)
+type ICheckListItemTemplate = Omit<
+  ICheckListItem,
+  "Id" | "RequestId" | "Active"
+> & {
+  Prereqs: templates[];
+};
 
-  const checklistItems = batchedSP.web.lists.getByTitle("CheckListItems");
-
-  // Welcome Package -- required for all inbounds
-  checklistItems.items.add({
+/** The list of tasks and their prerequisite tasks */
+export const checklistTemplates: ICheckListItemTemplate[] = [
+  {
     Title: "Send Welcome Package/Reference Guide",
     Lead: RoleType.SUPERVISOR,
-    RequestId: request.Id,
     TemplateId: templates.WelcomePackage,
-    Active: true,
     Description: `<p style="margin-top: 0px"><a href="https://usaf.dps.mil/sites/22539/Docs%20Shared%20to%20All/XP%20InOut%20Processing%20Automation%20Links/New%20Employee%20Reference%20Guide.docx">Send Welcome Package/Reference Guide</a></p>`,
-  } as ICheckListItem);
-
-  // IA Training -- Required for all inbounds
-  checklistItems.items.add({
+    Prereqs: [],
+  },
+  {
     Title: "IA Training Complete",
     Lead: RoleType.EMPLOYEE,
-    RequestId: request.Id,
     TemplateId: templates.IA_Training,
-    Active: true,
     Description: `<div><p style="margin-top: 0px">Information Assurance (IA) Training is an annual requirement. It is accomplished by completing the Cyber Awareness Challenge. It is mandatory that each employee be current in this training. Below are links to both a public (non-CAC) method for obtaining IA Training as well as myLearning for those with CACs. <b>Supervisors should provide non-CAC new employees with appropriate public website (item #1 below) so employee may complete training prior to installation in-processing.</b> If you have previously taken IA Training as a government employee and would like to check your training currency, go to Air Force myLearning below and view your training transcript.</p> 
 <p>1) No CAC - <a href="https://public.cyber.mil/training/cyber-awareness-challenge/">https://public.cyber.mil/training/cyber-awareness-challenge/</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;a) Upon completing the Cyber Awareness Challenge, download the completion certificate as a PDF, and send it to your supervisor and to the AFLCMC/OZI Enterprise Tech Team &lt;<a href="mailto:AFLCMC.OZI.EnterpriseTechTeam@us.af.mil">AFLCMC.OZI.EnterpriseTechTeam@us.af.mil</a>&gt;</p> 
 <p>2) CAC - Air Force myLearning (<a href="https://lms-jets.cce.af.mil/moodle/">https://lms-jets.cce.af.mil/moodle/</a>)<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;a) Once within the website, click on the Total Force Awareness Training Button, then scroll down to the Cyber Awareness Challenge and select the training.</p>
 </div>`,
-  } as ICheckListItem);
-
-  // Installation In Processing (required for new Mil/Civ)
-  if (request.isNewCivMil === "yes") {
-    checklistItems.items.add({
-      Title: "Attend Installation In-processing",
-      Lead: RoleType.EMPLOYEE,
-      RequestId: request.Id,
-      TemplateId: templates.InstallationInProcess,
-      Active: true,
-      Description: `<div><p style="margin-top: 0px">Did you attend the 88FSS installation in-processing? </p></div>`,
-    } as ICheckListItem);
-  }
-
-  // Obtain/Transfer CAC (Mil/Civ)
-  if (
-    request.empType === EMPTYPES.Civilian ||
-    request.empType === EMPTYPES.Military
-  ) {
-    checklistItems.items.add({
-      Title: "Obtain CAC (Mil/Civ)",
-      Lead: RoleType.EMPLOYEE,
-      RequestId: request.Id,
-      TemplateId: templates.ObtainCACGov,
-      Active: !(request.isNewCivMil === "yes"),
-      Description: `<div><p style="margin-top: 0px"><b>Initial CAC for brand new employees</b><br/>
+    Prereqs: [],
+  },
+  {
+    Title: "Obtain CAC (Mil/Civ)",
+    Lead: RoleType.EMPLOYEE,
+    TemplateId: templates.ObtainCACGov,
+    Description: `<div><p style="margin-top: 0px"><b>Initial CAC for brand new employees</b><br/>
 For brand new employees who have not yet obtained their CAC, please see 'Installation In-processing' as this task will address enrollment in the Defense Enrollment Eligibility Reporting System (DEERS) and provide guidance for scheduling a CAC appointment.</p>
 <p><b>Replacement CAC</b><br/>
 To schedule your CAC appointment see the following announcement:</p>
@@ -106,18 +89,13 @@ Transition Timeframe: <br/>
 customers can access Setmore/RAPIDS sites directly at the following links:<br/>
 Setmore: <a href="https://88fss.setmore.com/88fss">https://88fss.setmore.com/88fss</a><br/>
 RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mil/idco/</a><br/></p></div>`,
-    } as ICheckListItem);
-  }
-
-  // Obtain/Transfer CAC (Ctr)
-  if (request.empType === EMPTYPES.Contractor) {
-    checklistItems.items.add({
-      Title: "Obtain/Transfer CAC (Ctr)",
-      Lead: RoleType.EMPLOYEE,
-      RequestId: request.Id,
-      TemplateId: templates.ObtainCACCtr,
-      Active: true,
-      Description: `<div><p style="margin-top: 0px"><b><u>CAC Transfer</u></b><br/>This applies to contractors who meet the following conditions:
+    Prereqs: [templates.InstallationInProcess],
+  },
+  {
+    Title: "Obtain/Transfer CAC (Ctr)",
+    Lead: RoleType.EMPLOYEE,
+    TemplateId: templates.ObtainCACCtr,
+    Description: `<div><p style="margin-top: 0px"><b><u>CAC Transfer</u></b><br/>This applies to contractors who meet the following conditions:
 <ol><li>Possess a CAC issued under a DoD contract</li><li>Changing contracts away from the one which authorized and is associated with the CAC</li><li>Remaining in the employment of the same contractor through whom the CAC was issued</li></ol></p>
 <p>If you have current CAC issued under a government contract that you are changing and yet remaining with the same contractor, you may not be required to obtain a new CAC but may transfer the one you have. However, this requires working with your security office to coordinate the updating of your CAC to the appropriate contract.</p>
 <p><b><u>Obtain New or Replacement CAC</u></b><br/>To schedule your CAC appointment see the following announcement:</p>
@@ -129,148 +107,49 @@ Transition Timeframe: <br/>
 customers can access Setmore/RAPIDS sites directly at the following links:<br/>
 Setmore: <a href="https://88fss.setmore.com/88fss">https://88fss.setmore.com/88fss</a><br/>
 RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mil/idco/</a><br/></p></div>`,
-    } as ICheckListItem);
-  }
-
-  // Obtain building access -- Required for all inbounds
-  checklistItems.items.add({
-    Title: "Obtain building access",
+    Prereqs: [],
+  },
+  {
+    Title: "Attend Installation In-processing",
     Lead: RoleType.EMPLOYEE,
-    RequestId: request.Id,
-    TemplateId: templates.BuildingAccess,
-    Active: false,
+    TemplateId: templates.InstallationInProcess,
+    Description: `<div><p style="margin-top: 0px">Did you attend the 88FSS installation in-processing? </p></div>`,
+    Prereqs: [],
+  },
+  //  GTC -- TODO -- Not yet created
+  {
+    Title: "Profile created/re-assigned in DTS",
+    Lead: RoleType.DTS,
+    TemplateId: templates.DTS,
     Description: `<p style="margin-top: 0px">None</p>`,
-  } as ICheckListItem);
-
-  // Supervisor Coordination of 2875 -- Required for all inbounds
-  checklistItems.items.add({
-    Title: "Supervisor Coordination of 2875",
-    Lead: RoleType.SUPERVISOR,
-    RequestId: request.Id,
-    TemplateId: templates.SupervisorCoord2875,
-    Active: false,
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    Title: "Create/Update ATAAPS account",
+    Lead: RoleType.ATAAPS,
+    TemplateId: templates.ATAAPS,
     Description: `<p style="margin-top: 0px">None</p>`,
-  } as ICheckListItem);
-
-  // Security Coordination of 2875 -- Required for all inbounds
-  checklistItems.items.add({
-    Title: "Security Coordination of 2875",
-    Lead: RoleType.SECURITY,
-    RequestId: request.Id,
-    TemplateId: templates.SecurityCoord2875,
-    Active: false,
-    Description: `<p style="margin-top: 0px">None</p>`,
-  } as ICheckListItem);
-
-  // Provision/move AFNET account -- Required for all inbounds
-  checklistItems.items.add({
-    Title: "Provision/move AFNET account",
-    Lead: RoleType.IT,
-    RequestId: request.Id,
-    TemplateId: templates.ProvisionAFNET,
-    Active: false,
-    Description: `<p style="margin-top: 0px">None</p>`,
-  } as ICheckListItem);
-
-  // Equipment Issue -- Required for all inbounds
-  checklistItems.items.add({
-    Title: "Equipment Issue",
-    Lead: RoleType.IT,
-    RequestId: request.Id,
-    TemplateId: templates.EquipmentIssue,
-    Active: false,
-    Description: `<p style="margin-top: 0px">None</p>`,
-  } as ICheckListItem);
-
-  // Add to security groups -- Required for all inbounds
-  checklistItems.items.add({
-    Title: "Add to security groups",
-    Lead: RoleType.IT,
-    RequestId: request.Id,
-    TemplateId: templates.AddSecurityGroups,
-    Active: false,
-    Description: `<p style="margin-top: 0px">None</p>`,
-  } as ICheckListItem);
-
-  // Complete security training
-  checklistItems.items.add({
-    Title: "Complete security training",
-    Lead: RoleType.EMPLOYEE,
-    RequestId: request.Id,
-    TemplateId: templates.SecurityTraining,
-    Active: false,
-    Description: `<p style="margin-top: 0px">Review the Mandatory initial training slides and ensure you complete the survey at the end to receive credit</p>
-    <p>The slides can be found at <a href="https://usaf.dps.mil/:p:/r/teams/AFLCMCCSO/_layouts/15/Doc.aspx?sourcedoc=%7BC6E442DB-B72B-4AB6-9B80-1613F4281F48%7D&file=Initial%20CSO%20Training.pptx&action=edit&mobileredirect=true">https://usaf.dps.mil/:p:/r/teams/AFLCMCCSO/_layouts/15/Doc.aspx?sourcedoc=%7BC6E442DB-B72B-4AB6-9B80-1613F4281F48%7D&file=Initial%20CSO%20Training.pptx&action=edit&mobileredirect=true</p>`,
-  } as ICheckListItem);
-
-  // Confirm security training complete
-  checklistItems.items.add({
-    Title: "Confirm security training complete",
-    Lead: RoleType.SECURITY,
-    RequestId: request.Id,
-    TemplateId: templates.ConfirmSecurityTraining,
-    Active: false,
-    Description: `<p style="margin-top: 0px">Confirm member has taken required initial security training by reviewing survey results </p>`,
-  } as ICheckListItem);
-
-  // Verify Air Force myLearning account
-  checklistItems.items.add({
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
     Title: "Verify Air Force myLearning account",
     Lead: RoleType.EMPLOYEE,
-    RequestId: request.Id,
     TemplateId: templates.VerifyMyLearn,
-    Active: false,
     Description: `<div><p style="margin-top: 0px">As part of in-processing, all employees are to verify or register for an Air Force myLearning training account. This account is necessary for the completion of mandatory training requirements.</p>
 <p><a href="https://lms-jets.cce.af.mil/moodle/">Air Force MyLearning</a></p></div>`,
-  } as ICheckListItem);
-
-  // Confirm Air Force myLearning account
-  checklistItems.items.add({
-    Title: "Confirm Air Force myLearning account",
-    Lead: RoleType.SUPERVISOR,
-    RequestId: request.Id,
-    TemplateId: templates.ConfirmMyLearn,
-    Active: false,
-    Description: `<div><p style="margin-top: 0px">Click here for link to Air Force myLearning account: <a href="https://lms-jets.cce.af.mil/moodle/">Air Force MyLearning</a></p></div>`,
-  } as ICheckListItem);
-
-  // Verify AFMC myETMS account - CIV/MIL only
-  if (
-    request.empType === EMPTYPES.Civilian ||
-    request.empType === EMPTYPES.Military
-  ) {
-    checklistItems.items.add({
-      Title: "Verify AFMC myETMS account",
-      Lead: RoleType.EMPLOYEE,
-      RequestId: request.Id,
-      TemplateId: templates.VerifyMyETMS,
-      Active: false,
-      Description: `<div><p style="margin-top: 0px">Click here for link to myETMS: <a href="https://myetms.wpafb.af.mil/myetmsasp/main.asp">Air Force Materiel Command's myEducation and Training Management System</a></p></div>`,
-    } as ICheckListItem);
-  }
-
-  // Confirm AFMC myETMS account - CIV/MIL Only
-  if (
-    request.empType === EMPTYPES.Civilian ||
-    request.empType === EMPTYPES.Military
-  ) {
-    checklistItems.items.add({
-      Title: "Confirm AFMC myETMS account",
-      Lead: RoleType.SUPERVISOR,
-      RequestId: request.Id,
-      TemplateId: templates.ConfirmMyETMS,
-      Active: false,
-      Description: `<div><p style="margin-top: 0px">Click here for link to myETMS: <a href="https://myetms.wpafb.af.mil/myetmsasp/main.asp">Air Force Materiel Command's myEducation and Training Management System</a></p></div>`,
-    } as ICheckListItem);
-  }
-
-  // Mandatory training (all employees)
-  checklistItems.items.add({
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    Title: "Verify AFMC myETMS account",
+    Lead: RoleType.EMPLOYEE,
+    TemplateId: templates.VerifyMyETMS,
+    Description: `<div><p style="margin-top: 0px">Click here for link to myETMS: <a href="https://myetms.wpafb.af.mil/myetmsasp/main.asp">Air Force Materiel Command's myEducation and Training Management System</a></p></div>`,
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
     Title: "Complete mandatory training",
     Lead: RoleType.EMPLOYEE,
-    RequestId: request.Id,
     TemplateId: templates.MandatoryTraining,
-    Active: false,
     Description: `<div><p style="margin-top: 0px">The table below provides a course list of mandatory training for all employees. Employee status can be found for these courses in MyLearning and MyETMS. Course enrollment will be accomplished via MyLearning. Please confirm all training requirements are met prior to completing this checklist item.</p>
     <p><a href="https://lms-jets.cce.af.mil/moodle/course/index.php?categoryid=173">myLearning - Total Force Awareness Training (TFAT)</a><br/>
     <a href="https://myetms.wpafb.af.mil/myetmsasp/main.asp">myETMS - Training Requirements</a></p>
@@ -285,77 +164,69 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
  <tr><td>Controlled Unclassified Information (CUI) Training (ZZZ2021CUI)</td><td>Annual</td></tr>
  <tr><td>Religious Freedom Training (ZZ133109)</td><td>Every 3 years</td></tr>
 </table></div>`,
-  } as ICheckListItem);
-
-  // Confirm Mandatory training (all employees)
-  checklistItems.items.add({
-    Title: "Confirm mandatory training complete",
-    Lead: RoleType.SUPERVISOR,
-    RequestId: request.Id,
-    TemplateId: templates.ConfirmMandatoryTraining,
-    Active: false,
-    Description: `<div><p style="margin-top: 0px">None</p></div>`,
-  } as ICheckListItem);
-
-  // Supervisor training (Supervisory positions only)
-  if (request.isSupervisor === "yes") {
-    checklistItems.items.add({
-      Title: "Complete supervisor training",
-      Lead: RoleType.EMPLOYEE,
-      RequestId: request.Id,
-      TemplateId: templates.SupervisorTraining,
-      Active: true,
-      Description: `<div><p style="margin-top: 0px">Please look for Air University to provide guidance (online training link) for the completion of all appropriate supervisor training requirements.</p></div>`,
-    } as ICheckListItem);
-  }
-
-  // Set up phone system (all Employees) -- requires user to have CAC first
-  checklistItems.items.add({
+    Prereqs: [templates.VerifyMyETMS, templates.VerifyMyLearn],
+  },
+  {
     Title: "Set up phone system",
     Lead: RoleType.EMPLOYEE,
-    RequestId: request.Id,
-    TemplateId: templates.PhoneSetup,
-    Active: false,
-    Description: `<p style="margin-top: 0px">See the following link for phone set up instructions: <a href="https://www.tsf.wpafb.af.mil/Doc/Getting%20Started%20with%20the%20UC%20Client.pdf">Getting started with the UC Client</a></p>`,
-  } as ICheckListItem);
 
-  // Watch Orientation Videos (all Employees) -- requires user to have CAC first
-  checklistItems.items.add({
+    TemplateId: templates.PhoneSetup,
+    Description: `<p style="margin-top: 0px">See the following link for phone set up instructions: <a href="https://www.tsf.wpafb.af.mil/Doc/Getting%20Started%20with%20the%20UC%20Client.pdf">Getting started with the UC Client</a></p>`,
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
     Title: "View orientation videos",
     Lead: RoleType.EMPLOYEE,
-    RequestId: request.Id,
     TemplateId: templates.OrientationVideos,
-    Active: false,
     Description: `<p style="margin-top: 0px">The orientation videos may be found within the following document: <a href="https://usaf.dps.mil/sites/22539/Docs%20Shared%20to%20All/XP%20InOut%20Processing%20Automation%20Links/New%20Employee%20Websites.docx">New Employee Websites.docx</a></p>`,
-  } as ICheckListItem);
-
-  // Bookmark SharePoint/Websites (all Employees) -- requires user to have CAC first
-  checklistItems.items.add({
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
     Title: "Bookmark key SharePoint / Website URLs",
     Lead: RoleType.EMPLOYEE,
-    RequestId: request.Id,
     TemplateId: templates.Bookmarks,
-    Active: false,
     Description: `<p style="margin-top: 0px">Bookmark the links located in the document located here: <a href="https://usaf.dps.mil/sites/22539/Docs%20Shared%20to%20All/XP%20InOut%20Processing%20Automation%20Links/New%20Employee%20Websites.docx">New Employee Websites.docx</a></p>`,
-  } as ICheckListItem);
-
-  // Newcomer Breifing (all Employees) -- requires user to have CAC first
-  checklistItems.items.add({
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
     Title: "Review directorate newcomer brief",
     Lead: RoleType.EMPLOYEE,
-    RequestId: request.Id,
     TemplateId: templates.NewcomerBrief,
-    Active: false,
     Description: `<p style="margin-top: 0px">Review directorate newcomer brief located here: <a href="https://usaf.dps.mil/sites/22539/Docs%20Shared%20to%20All/XP%20InOut%20Processing%20Automation%20Links/AFLCMC%20-%20XP-OZ%20Overview.pptx">AFLCMC - XP-OZ Overview.pptx</a></p>`,
-  } as ICheckListItem);
-
-  // Unit orientation conducted (all Employees)
-  checklistItems.items.add({
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    Title: "Complete supervisor training",
+    Lead: RoleType.EMPLOYEE,
+    TemplateId: templates.SupervisorTraining,
+    Description: `<div><p style="margin-top: 0px">Please look for Air University to provide guidance (online training link) for the completion of all appropriate supervisor training requirements.</p></div>`,
+    Prereqs: [],
+  },
+  {
+    Title: "Confirm mandatory training complete",
+    Lead: RoleType.SUPERVISOR,
+    TemplateId: templates.ConfirmMandatoryTraining,
+    Description: `<div><p style="margin-top: 0px">None</p></div>`,
+    Prereqs: [templates.MandatoryTraining],
+  },
+  {
+    Title: "Confirm Air Force myLearning account",
+    Lead: RoleType.SUPERVISOR,
+    TemplateId: templates.ConfirmMyLearn,
+    Description: `<div><p style="margin-top: 0px">Click here for link to Air Force myLearning account: <a href="https://lms-jets.cce.af.mil/moodle/">Air Force MyLearning</a></p></div>`,
+    Prereqs: [templates.VerifyMyLearn],
+  },
+  {
+    Title: "Confirm AFMC myETMS account",
+    Lead: RoleType.SUPERVISOR,
+    TemplateId: templates.ConfirmMyETMS,
+    Description: `<div><p style="margin-top: 0px">Click here for link to myETMS: <a href="https://myetms.wpafb.af.mil/myetmsasp/main.asp">Air Force Materiel Command's myEducation and Training Management System</a></p></div>`,
+    Prereqs: [templates.VerifyMyETMS],
+  },
+  {
     Title: "Unit orientation conducted",
     Lead: RoleType.SUPERVISOR,
-    RequestId: request.Id,
     TemplateId: templates.UnitOrientation,
-    Active: true,
     Description: `<p style="margin-top: 0px">Please ensure employee are briefed in the following key areas:
 <ul>
 <li>Explain the unit Chain of Command</li>
@@ -372,94 +243,271 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
 <li>Obtain recall roster information</li>
 <li>Discuss welcome package / reference guide</li>
 </ul></p>`,
-  } as ICheckListItem);
-
-  // Create & brief 971 folder
-  checklistItems.items.add({
+    Prereqs: [],
+  },
+  {
     Title: "Create & brief 971 folder",
     Lead: RoleType.SUPERVISOR,
-    RequestId: request.Id,
     TemplateId: templates.Brief971Folder,
-    Active: true,
     Description: `<p style="margin-top: 0px">None</p>`,
-  } as ICheckListItem);
-
-  // Signed performance/contribution plan
-  checklistItems.items.add({
+    Prereqs: [],
+  },
+  {
     Title: "Signed performance/contribution plan",
     Lead: RoleType.SUPERVISOR,
-    RequestId: request.Id,
     TemplateId: templates.SignedPerformContribPlan,
-    Active: false,
     Description: `<p style="margin-top: 0px">None</p>`,
-  } as ICheckListItem);
-
-  // Signed telework agreement
-  checklistItems.items.add({
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
     Title: "Signed telework agreement",
     Lead: RoleType.SUPERVISOR,
-    RequestId: request.Id,
     TemplateId: templates.SignedTeleworkAgreement,
-    Active: false,
     Description: `<p style="margin-top: 0px"><a href="https://usaf.dps.mil/sites/22539/Docs%20Shared%20to%20All/XP%20InOut%20Processing%20Automation%20Links/Telework%20Agreement%20Form%20dd2946.pdf">Telework Agreement Form DD2946</a></p>`,
-  } as ICheckListItem);
-
-  // Telework status entered in WHAT
-  checklistItems.items.add({
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
     Title: "Telework status entered in WHAT",
     Lead: RoleType.SUPERVISOR,
-    RequestId: request.Id,
     TemplateId: templates.TeleworkAddedToWHAT,
-    Active: false,
     Description: `<p style="margin-top: 0px"><a href="https://usaf.dps.mil/teams/10251/WHAT">Workforce Hybrid Analysis Tool (WHAT)</a></p>`,
-  } as ICheckListItem);
+    Prereqs: [templates.SignedTeleworkAgreement],
+  },
+  {
+    Title: "Supervisor Coordination of 2875",
+    Lead: RoleType.SUPERVISOR,
+    TemplateId: templates.SupervisorCoord2875,
+    Description: `<p style="margin-top: 0px">None</p>`,
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    Title: "Security Coordination of 2875",
+    Lead: RoleType.SECURITY,
+    TemplateId: templates.SecurityCoord2875,
+    Description: `<p style="margin-top: 0px">None</p>`,
+    Prereqs: [templates.SupervisorCoord2875],
+  },
+  {
+    Title: "Provision/move AFNET account",
+    Lead: RoleType.IT,
+    TemplateId: templates.ProvisionAFNET,
+    Description: `<p style="margin-top: 0px">None</p>`,
+    Prereqs: [templates.SecurityCoord2875],
+  },
+  {
+    Title: "Equipment Issue",
+    Lead: RoleType.IT,
+    TemplateId: templates.EquipmentIssue,
+    Description: `<p style="margin-top: 0px">None</p>`,
+    Prereqs: [templates.SecurityCoord2875],
+  },
+  {
+    Title: "Add to security groups",
+    Lead: RoleType.IT,
+    TemplateId: templates.AddSecurityGroups,
+    Description: `<p style="margin-top: 0px">None</p>`,
+    Prereqs: [templates.ProvisionAFNET],
+  },
+  {
+    Title: "Obtain building access",
+    Lead: RoleType.EMPLOYEE,
+    TemplateId: templates.BuildingAccess,
+    Description: `<p style="margin-top: 0px">None</p>`,
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    Title: "Verify direct deposit active",
+    Lead: RoleType.ATAAPS,
+    TemplateId: templates.VerifyDirectDeposit,
+    Description: `<p style="margin-top: 0px">None</p>`,
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    Title: "Verify tax status accurate",
+    Lead: RoleType.ATAAPS,
+    TemplateId: templates.VerifyTaxStatus,
+    Description: `<p style="margin-top: 0px">None</p>`,
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+  {
+    Title: "Complete security training",
+    Lead: RoleType.EMPLOYEE,
+    TemplateId: templates.SecurityTraining,
+    Description: `<p style="margin-top: 0px">Review the Mandatory initial training slides and ensure you complete the survey at the end to receive credit</p>
+    <p>The slides can be found at <a href="https://usaf.dps.mil/:p:/r/teams/AFLCMCCSO/_layouts/15/Doc.aspx?sourcedoc=%7BC6E442DB-B72B-4AB6-9B80-1613F4281F48%7D&file=Initial%20CSO%20Training.pptx&action=edit&mobileredirect=true">https://usaf.dps.mil/:p:/r/teams/AFLCMCCSO/_layouts/15/Doc.aspx?sourcedoc=%7BC6E442DB-B72B-4AB6-9B80-1613F4281F48%7D&file=Initial%20CSO%20Training.pptx&action=edit&mobileredirect=true</p>`,
+    Prereqs: [templates.ProvisionAFNET],
+  },
+  {
+    Title: "Confirm security training complete",
+    Lead: RoleType.SECURITY,
+    TemplateId: templates.ConfirmSecurityTraining,
+    Description: `<p style="margin-top: 0px">Confirm member has taken required initial security training by reviewing survey results </p>`,
+    Prereqs: [templates.SecurityTraining],
+  },
+  {
+    Title: "Security requirements & access",
+    Lead: RoleType.SECURITY,
+    TemplateId: templates.SecurityRequirements,
+    Description: `<p style="margin-top: 0px">Review the members, Security Access Requirement (SAR) Code, Position Sensitivity Code, and Clearance Eligibility and update appropriate access level</p>
+      <p>Establish a servicing or owning relationship with the member in the Defense Information System for Security (DISS)</p>`,
+    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
+  },
+];
+
+const createInboundChecklistItems = (request: IInRequest) => {
+  const [batchedSP, execute] = spWebContext.batched();
+  const checklistItems = batchedSP.web.lists.getByTitle("CheckListItems");
+
+  /**
+   * Function to call the PnPJS function to create the item
+   * @param templateId The ID of the template to use for creating the Checklist Item
+   */
+  const addChecklistItem = (templateId: templates) => {
+    const itemTemplate = checklistTemplates.find(
+      (item2) => item2.TemplateId === templateId
+    );
+    if (itemTemplate) {
+      checklistItems.items.add({
+        Title: itemTemplate.Title,
+        Lead: itemTemplate.Lead,
+        RequestId: request.Id,
+        TemplateId: itemTemplate.TemplateId,
+        Active:
+          // Special case for ObtainCacGov where we set to true if they are not a new Civ/Mil as then there is no prereq
+          itemTemplate.TemplateId === templates.ObtainCACGov &&
+          request.isNewCivMil === "no"
+            ? true
+            : itemTemplate.Prereqs.length === 0,
+        Description: itemTemplate.Description,
+      } as ICheckListItem);
+    }
+  };
+
+  // Welcome Package -- required for all inbounds
+  addChecklistItem(templates.WelcomePackage);
+
+  // IA Training -- Required for all inbounds
+  addChecklistItem(templates.IA_Training);
+
+  // Installation In Processing (required for new Mil/Civ)
+  if (request.isNewCivMil === "yes") {
+    addChecklistItem(templates.InstallationInProcess);
+  }
+
+  // Obtain/Transfer CAC (Mil/Civ)
+  if (
+    request.empType === EMPTYPES.Civilian ||
+    request.empType === EMPTYPES.Military
+  ) {
+    addChecklistItem(templates.ObtainCACGov);
+  }
+
+  // Obtain/Transfer CAC (Ctr)
+  if (request.empType === EMPTYPES.Contractor) {
+    addChecklistItem(templates.ObtainCACCtr);
+  }
+
+  // Obtain building access -- Required for all inbounds
+  addChecklistItem(templates.BuildingAccess);
+
+  // Supervisor Coordination of 2875 -- Required for all inbounds
+  addChecklistItem(templates.SupervisorCoord2875);
+
+  // Security Coordination of 2875 -- Required for all inbounds
+  addChecklistItem(templates.SecurityCoord2875);
+
+  // Provision/move AFNET account -- Required for all inbounds
+  addChecklistItem(templates.ProvisionAFNET);
+
+  // Equipment Issue -- Required for all inbounds
+  addChecklistItem(templates.EquipmentIssue);
+
+  // Add to security groups -- Required for all inbounds
+  addChecklistItem(templates.AddSecurityGroups);
+
+  // Complete security training
+  addChecklistItem(templates.SecurityTraining);
+
+  // Confirm security training complete
+  addChecklistItem(templates.ConfirmSecurityTraining);
+
+  // Verify Air Force myLearning account
+  addChecklistItem(templates.VerifyMyLearn);
+
+  // Confirm Air Force myLearning account
+  addChecklistItem(templates.ConfirmMyLearn);
+
+  // Verify AFMC myETMS account - CIV/MIL only
+  if (
+    request.empType === EMPTYPES.Civilian ||
+    request.empType === EMPTYPES.Military
+  ) {
+    addChecklistItem(templates.VerifyMyETMS);
+  }
+
+  // Confirm AFMC myETMS account - CIV/MIL Only
+  if (
+    request.empType === EMPTYPES.Civilian ||
+    request.empType === EMPTYPES.Military
+  ) {
+    addChecklistItem(templates.ConfirmMyETMS);
+  }
+
+  // Mandatory training (all employees)
+  addChecklistItem(templates.MandatoryTraining);
+
+  // Confirm Mandatory training (all employees)
+  addChecklistItem(templates.ConfirmMandatoryTraining);
+
+  // Supervisor training (Supervisory positions only)
+  if (request.isSupervisor === "yes") {
+    addChecklistItem(templates.SupervisorTraining);
+  }
+
+  // Set up phone system (all Employees) -- requires user to have CAC first
+  addChecklistItem(templates.PhoneSetup);
+
+  // Watch Orientation Videos (all Employees) -- requires user to have CAC first
+  addChecklistItem(templates.OrientationVideos);
+
+  // Bookmark SharePoint/Websites (all Employees) -- requires user to have CAC first
+  addChecklistItem(templates.Bookmarks);
+
+  // Newcomer Breifing (all Employees) -- requires user to have CAC first
+  addChecklistItem(templates.NewcomerBrief);
+
+  // Unit orientation conducted (all Employees)
+  addChecklistItem(templates.UnitOrientation);
+
+  // Create & brief 971 folder
+  addChecklistItem(templates.Brief971Folder);
+
+  // Signed performance/contribution plan
+  addChecklistItem(templates.SignedPerformContribPlan);
+
+  // Signed telework agreement
+  addChecklistItem(templates.SignedTeleworkAgreement);
+
+  // Telework status entered in WHAT
+  addChecklistItem(templates.TeleworkAddedToWHAT);
 
   // Create/Update ATAAPS account - CIV only
   if (request.empType === EMPTYPES.Civilian) {
-    checklistItems.items.add({
-      Title: "Create/Update ATAAPS account",
-      Lead: RoleType.ATAAPS,
-      RequestId: request.Id,
-      TemplateId: templates.ATAAPS,
-      Active: false,
-      Description: `<p style="margin-top: 0px">None</p>`,
-    } as ICheckListItem);
+    addChecklistItem(templates.ATAAPS);
   }
 
   // Verify direct deposit active - CIV only
   if (request.empType === EMPTYPES.Civilian) {
-    checklistItems.items.add({
-      Title: "Verify direct deposit active",
-      Lead: RoleType.ATAAPS,
-      RequestId: request.Id,
-      TemplateId: templates.VerifyDirectDeposit,
-      Active: false,
-      Description: `<p style="margin-top: 0px">None</p>`,
-    } as ICheckListItem);
+    addChecklistItem(templates.VerifyDirectDeposit);
   }
 
   // Verify tax status accurate - CIV only
   if (request.empType === EMPTYPES.Civilian) {
-    checklistItems.items.add({
-      Title: "Verify tax status accurate",
-      Lead: RoleType.ATAAPS,
-      RequestId: request.Id,
-      TemplateId: templates.VerifyTaxStatus,
-      Active: false,
-      Description: `<p style="margin-top: 0px">None</p>`,
-    } as ICheckListItem);
+    addChecklistItem(templates.VerifyTaxStatus);
   }
 
   // Security requirements & access
-  checklistItems.items.add({
-    Title: "Security requirements & access",
-    Lead: RoleType.SECURITY,
-    RequestId: request.Id,
-    TemplateId: templates.SecurityRequirements,
-    Active: false,
-    Description: `<p style="margin-top: 0px">Review the members, Security Access Requirement (SAR) Code, Position Sensitivity Code, and Clearance Eligibility and update appropriate access level</p>
-      <p>Establish a servicing or owning relationship with the member in the Defense Information System for Security (DISS)</p>`,
-  } as ICheckListItem);
+  addChecklistItem(templates.SecurityRequirements);
 
   // Profile created/re-assigned in DTS -- CIV/MIL with Travel required
   if (
@@ -467,19 +515,8 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
     (request.empType === EMPTYPES.Civilian ||
       request.empType === EMPTYPES.Military)
   ) {
-    checklistItems.items.add({
-      Title: "Profile created/re-assigned in DTS",
-      Lead: RoleType.DTS,
-      RequestId: request.Id,
-      TemplateId: templates.DTS,
-      Active: false,
-      Description: `<p style="margin-top: 0px">None</p>`,
-    } as ICheckListItem);
+    addChecklistItem(templates.DTS);
   }
-
-  // Training In-processing
-  // Supervisor In-processing
-  // ETT In-processing
 
   return execute();
 };

--- a/src/components/CheckList/CheckListItemPanel.tsx
+++ b/src/components/CheckList/CheckListItemPanel.tsx
@@ -8,6 +8,7 @@ import DOMPurify, { sanitize } from "dompurify";
 import { RoleType } from "api/RolesApi";
 import { IInRequest } from "api/RequestApi";
 import { CheckListItemButton } from "components/CheckList/CheckListItemButton";
+import { CheckListItemPrereq } from "./CheckListItemPrereq";
 
 DOMPurify.addHook("afterSanitizeAttributes", function (node) {
   if (node.tagName === "A") {
@@ -120,6 +121,21 @@ export const CheckListItemPanel: FunctionComponent<ICheckList> = (props) => {
                 <CheckListItemButton checklistItem={props.item} />
               )}
           </div>
+          {/* Only show the Prerequisite section if the Request is Active, and the Checklist Item is NOT Active */}
+          {props.request.status === "Active" && !props.item.Active && (
+            <div className={classes.fieldContainer}>
+              <Label
+                htmlFor="panelCompletion"
+                size="small"
+                weight="semibold"
+                className={classes.fieldLabel}
+              >
+                <InfoIcon className={classes.fieldIcon} />
+                Prerequisites
+              </Label>
+              <CheckListItemPrereq checklistItem={props.item} />
+            </div>
+          )}
         </div>
       </FluentProvider>
     </Panel>

--- a/src/components/CheckList/CheckListItemPrereq.tsx
+++ b/src/components/CheckList/CheckListItemPrereq.tsx
@@ -1,0 +1,52 @@
+import { Badge } from "@fluentui/react-components";
+import { CompletedIcon } from "@fluentui/react-icons-mdl2";
+import { ICheckListItem, useChecklistItems } from "api/CheckListItemApi";
+import { templatePreqs } from "api/CompleteChecklistItem";
+
+interface CheckListItemPrereqProps {
+  checklistItem: ICheckListItem;
+}
+
+export const CheckListItemPrereq = ({
+  checklistItem,
+}: CheckListItemPrereqProps) => {
+  // Get all the Checklist Items for this request so we can map them out
+  const checklistItems = useChecklistItems(checklistItem.RequestId);
+  let prereqItems: ICheckListItem[] = [];
+
+  if (checklistItems.data) {
+    // Locate the current checklist item's template
+    const thisTemp = templatePreqs.find(
+      (templ) => templ.templId === checklistItem.TemplateId
+    );
+
+    // If we have prereqs, then set the prereqItems to those Checklist Items
+    if (thisTemp && thisTemp.preReqs.length > 0) {
+      prereqItems = checklistItems.data.filter((item) =>
+        thisTemp.preReqs.includes(item.TemplateId)
+      );
+    }
+  } else {
+    // If we don't have data yet, show that we are Loading this section
+    return <>Loading</>;
+  }
+
+  return (
+    <>
+      {prereqItems.map((item) => {
+        return (
+          <Badge
+            size="extra-large"
+            appearance="ghost"
+            color={item.CompletedDate ? "success" : "informative"}
+            style={{ verticalAlign: "middle", justifyContent: "flex-start" }}
+            icon={item.CompletedDate ? <CompletedIcon /> : ""}
+            iconPosition="after"
+          >
+            {item.Title}
+          </Badge>
+        );
+      })}
+    </>
+  );
+};

--- a/src/components/CheckList/CheckListItemPrereq.tsx
+++ b/src/components/CheckList/CheckListItemPrereq.tsx
@@ -1,7 +1,7 @@
 import { Badge } from "@fluentui/react-components";
 import { CompletedIcon } from "@fluentui/react-icons-mdl2";
 import { ICheckListItem, useChecklistItems } from "api/CheckListItemApi";
-import { templatePreqs } from "api/CompleteChecklistItem";
+import { checklistTemplates } from "api/CreateChecklistItems";
 
 interface CheckListItemPrereqProps {
   checklistItem: ICheckListItem;
@@ -16,14 +16,14 @@ export const CheckListItemPrereq = ({
 
   if (checklistItems.data) {
     // Locate the current checklist item's template
-    const thisTemp = templatePreqs.find(
-      (templ) => templ.templId === checklistItem.TemplateId
+    const thisTemp = checklistTemplates.find(
+      (templ) => templ.TemplateId === checklistItem.TemplateId
     );
 
     // If we have prereqs, then set the prereqItems to those Checklist Items
-    if (thisTemp && thisTemp.preReqs.length > 0) {
+    if (thisTemp && thisTemp.Prereqs.length > 0) {
       prereqItems = checklistItems.data.filter((item) =>
-        thisTemp.preReqs.includes(item.TemplateId)
+        thisTemp.Prereqs.includes(item.TemplateId)
       );
     }
   } else {


### PR DESCRIPTION
When a task is Inactive, show the user which task(s) are the immediate prerequisites that need completed first to enable the task.
Refactored creation of items to use a template object with Prereqs defined, and derive whether or not it should initialize as Active based on if there are Prerequisite tasks.