### PR TITLE
Reactivate checklist item

### DIFF
--- a/src/api/ReactivateChecklistItem.ts
+++ b/src/api/ReactivateChecklistItem.ts
@@ -1,0 +1,27 @@
+import { ICheckListItem } from "api/CheckListItemApi";
+import { spWebContext } from "providers/SPWebContext";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export const useReactivateChecklistItem = (item: ICheckListItem) => {
+  const queryClient = useQueryClient();
+
+  /** Function called by the React Query useMutation */
+  const completeCheckListItem = () => {
+    // Clear the CompletedBy and CompletedDate.
+    // To clear a Person field in SharePoint we must pass and Id of -1 and a StringId of ""
+    return spWebContext.web.lists
+      .getByTitle("ChecklistItems")
+      .items.getById(item.Id)
+      .update({
+        CompletedById: -1,
+        CompletedByStringId: "",
+        CompletedDate: null,
+      });
+  };
+
+  return useMutation(["checklist", item.Id], completeCheckListItem, {
+    onSuccess: () => {
+      return queryClient.invalidateQueries(["checklist"]);
+    },
+  });
+};

--- a/src/components/CheckList/CheckListItemPanel.tsx
+++ b/src/components/CheckList/CheckListItemPanel.tsx
@@ -8,7 +8,8 @@ import DOMPurify, { sanitize } from "dompurify";
 import { RoleType } from "api/RolesApi";
 import { IInRequest } from "api/RequestApi";
 import { CheckListItemButton } from "components/CheckList/CheckListItemButton";
-import { CheckListItemPrereq } from "./CheckListItemPrereq";
+import { CheckListItemPrereq } from "components/CheckList/CheckListItemPrereq";
+import { CheckListItemReactivateButton } from "components/CheckList/CheckListItemReactivateButton";
 
 DOMPurify.addHook("afterSanitizeAttributes", function (node) {
   if (node.tagName === "A") {
@@ -136,6 +137,23 @@ export const CheckListItemPanel: FunctionComponent<ICheckList> = (props) => {
               <CheckListItemPrereq checklistItem={props.item} />
             </div>
           )}
+          {/* Only show the Reactivate section if the Request is Active, and the Checklist Item is Completed, and the User is the Lead  */}
+          {props.request.status === "Active" &&
+            props.item.CompletedBy &&
+            props.roles?.includes(props.item.Lead) && (
+              <div className={classes.fieldContainer}>
+                <Label
+                  htmlFor="reactivationButton"
+                  size="small"
+                  weight="semibold"
+                  className={classes.fieldLabel}
+                >
+                  <InfoIcon className={classes.fieldIcon} />
+                  Reactivate Checklist Item
+                </Label>
+                <CheckListItemReactivateButton checklistItem={props.item} />
+              </div>
+            )}
         </div>
       </FluentProvider>
     </Panel>

--- a/src/components/CheckList/CheckListItemReactivateButton.tsx
+++ b/src/components/CheckList/CheckListItemReactivateButton.tsx
@@ -1,0 +1,61 @@
+import { ICheckListItem } from "api/CheckListItemApi";
+import { Button, Tooltip, Spinner, Badge } from "@fluentui/react-components";
+import { useReactivateChecklistItem } from "api/ReactivateChecklistItem";
+import { AlertSolidIcon } from "@fluentui/react-icons-mdl2";
+import { useIsMutating } from "@tanstack/react-query";
+
+interface CheckListItemReactivateButtonProps {
+  checklistItem: ICheckListItem;
+}
+
+export const CheckListItemReactivateButton = ({
+  checklistItem,
+}: CheckListItemReactivateButtonProps) => {
+  const reactivateCheckListItem = useReactivateChecklistItem(checklistItem);
+  const isMutating = useIsMutating({
+    mutationKey: ["checklist", checklistItem.Id],
+  });
+
+  // Because this button may be clicked, then the panel changed to another completed task
+  // we cannot use .isLoading because will be true if ANY item is currently using this mutation
+  // by using useIsMutating we can look for a specific mutation key
+  if (isMutating > 0) {
+    return (
+      <Spinner
+        style={{ justifyContent: "flex-start" }}
+        size="small"
+        label="Reactivating..."
+      />
+    );
+  }
+
+  return (
+    <>
+      <Button
+        name="reactivationButton"
+        appearance="secondary"
+        onClick={() => reactivateCheckListItem.mutate()}
+      >
+        Reactivate
+      </Button>
+      {reactivateCheckListItem.isError && (
+        <Tooltip
+          content={
+            reactivateCheckListItem.error instanceof Error
+              ? reactivateCheckListItem.error.message
+              : "An error occurred."
+          }
+          relationship="label"
+        >
+          <Badge
+            size="extra-large"
+            appearance="ghost"
+            color="danger"
+            style={{ verticalAlign: "middle" }}
+            icon={<AlertSolidIcon />}
+          />
+        </Tooltip>
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
Ability to reactivate a checklist item for an Active request

(AC1) - A lead can ONLY 're-active or un-complete' a completed checklist item of which they are the lead
(AC2) - A lead CANNOT 're-active or un-complete' a completed checklist item of which they are not the lead
(AC3) - The 're-actived / un-completed' checklist item will not affect or alter the existing status of any dependent checklist items
(AC4) - Cannot 're-active / un-complete' a checklist item for a request that has been either Closed or Cancelled