### PR TITLE
Feature/uat updates

### DIFF
--- a/src/components/InRequest/InRequest.tsx
+++ b/src/components/InRequest/InRequest.tsx
@@ -127,27 +127,30 @@ export const InRequest: FunctionComponent<IInRequestComp> = (props) => {
       {/* Only show the buttons to Supervisors -- and only show if it isn't Closed/Cancelled */}
       {isSupervisor && !props.request?.closedOrCancelledDate && (
         <div className={classes.supervisorButtonBar}>
-          <Button
-            appearance="subtle"
-            onClick={showEditPanel}
-            icon={<EditIcon />}
-            shape="circular"
-            size="small"
-            disabled={updateRequest.isLoading} // Disable if we are processing an update
-          >
-            Edit
-          </Button>
-          <Button
-            appearance="subtle"
-            onClick={showCancelDialog}
-            icon={<CancelIcon />}
-            shape="circular"
-            size="small"
-            disabled={updateRequest.isLoading} // Disable if we are processing an update
-          >
-            Cancel Request
-          </Button>
-
+          <Tooltip content={"Edit this request"} relationship={"description"}>
+            <Button
+              appearance="subtle"
+              onClick={showEditPanel}
+              icon={<EditIcon />}
+              shape="circular"
+              size="small"
+              disabled={updateRequest.isLoading} // Disable if we are processing an update
+            >
+              Edit
+            </Button>
+          </Tooltip>
+          <Tooltip content={"Cancel this request"} relationship={"description"}>
+            <Button
+              appearance="subtle"
+              onClick={showCancelDialog}
+              icon={<CancelIcon />}
+              shape="circular"
+              size="small"
+              disabled={updateRequest.isLoading} // Disable if we are processing an update
+            >
+              Cancel
+            </Button>
+          </Tooltip>
           {
             //Show a spinner if we are processing a "complete" request
             updateType === "complete" && updateRequest.isLoading ? (
@@ -157,8 +160,8 @@ export const InRequest: FunctionComponent<IInRequestComp> = (props) => {
                 <Tooltip
                   content={
                     checklistItemsToComplete === 0
-                      ? "Mark this request as complete"
-                      : "Cannot be marked complete until all checklist items have been completed"
+                      ? "Complete this request"
+                      : "Cannot be completed until all checklist items have been completed"
                   }
                   relationship={"description"}
                 >
@@ -173,7 +176,7 @@ export const InRequest: FunctionComponent<IInRequestComp> = (props) => {
                       checklistItemsToComplete !== 0 || updateRequest.isLoading
                     }
                   >
-                    Mark Complete
+                    Complete
                   </Button>
                 </Tooltip>
                 {

--- a/src/components/InRequest/InRequestEditPanel.tsx
+++ b/src/components/InRequest/InRequestEditPanel.tsx
@@ -258,7 +258,7 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                     disabled={employee?.text ? true : false}
                     aria-describedby="empNameErr"
                     id="empNameId"
-                    placeholder="Supply a manually entered name to be used until they are in the GAL.  Example 'Doe, Jack E'"
+                    placeholder="Supply a manually entered name to be used until they are in the GAL.  Example 'Last, First MI'"
                   />
                 )}
               />

--- a/src/components/InRequest/InRequestEditPanel.tsx
+++ b/src/components/InRequest/InRequestEditPanel.tsx
@@ -704,6 +704,14 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                         {errors.prevOrg.message}
                       </Text>
                     )}
+                    <Text
+                      weight="regular"
+                      size={200}
+                      className={classes.fieldDescription}
+                    >
+                      Entry should include Higher HQ / Directorate; examples
+                      AFRL/RD, AFLCMC/HI, SAF/AQ
+                    </Text>
                   </div>
                 )}
               </>

--- a/src/components/InRequest/InRequestNewForm.tsx
+++ b/src/components/InRequest/InRequestNewForm.tsx
@@ -718,6 +718,14 @@ export const InRequestNewForm = () => {
                   {errors.prevOrg.message}
                 </Text>
               )}
+              <Text
+                weight="regular"
+                size={200}
+                className={classes.fieldDescription}
+              >
+                Entry should include Higher HQ / Directorate; examples AFRL/RD,
+                AFLCMC/HI, SAF/AQ
+              </Text>
             </div>
           )}
         </>

--- a/src/components/InRequest/InRequestNewForm.tsx
+++ b/src/components/InRequest/InRequestNewForm.tsx
@@ -231,7 +231,7 @@ export const InRequestNewForm = () => {
               disabled={employee?.text ? true : false}
               aria-describedby="empNameErr"
               id="empNameId"
-              placeholder="Supply a manually entered name to be used until they are in the GAL.  Example 'Doe, Jack E'"
+              placeholder="Supply a manually entered name to be used until they are in the GAL.  Example 'Last, First MI'"
             />
           )}
         />

--- a/src/constants/GradeRanks.ts
+++ b/src/constants/GradeRanks.ts
@@ -25,7 +25,6 @@ export const NH_GRADES: IComboBoxOption[] = [
   { key: "NH-02", text: "NH-02" },
   { key: "NH-03", text: "NH-03" },
   { key: "NH-04", text: "NH-04" },
-  { key: "NH-05", text: "NH-05" },
 ];
 
 export const MIL_GRADES: IComboBoxOption[] = [


### PR DESCRIPTION
Wording updates and adding some tooltips to Request Actions buttons of "Cancel" and "Edit" to be consistent with "Complete"

Add tip to Previous Org field to get better data
Remove NH-05 as an option
Update manual name placeholder to specify Last, First MI rather than "Doe, Jack E"
Update the request actions to read as Actionable items. "Edit", "Cancel", and "Complete"
Add tooltips to "Edit" and "Cancel" to be consistent with "Complete" already having one
