### PR TITLE
UAT Update 6

### DIFF
--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -561,7 +561,9 @@ const createInboundChecklistItems = (request: IInRequest) => {
   addChecklistItem(templates.Brief971Folder);
 
   // Signed performance/contribution plan
-  addChecklistItem(templates.SignedPerformContribPlan);
+  if (request.empType === EMPTYPES.Civilian) {
+    addChecklistItem(templates.SignedPerformContribPlan);
+  }
 
   // Signed telework agreement
   addChecklistItem(templates.SignedTeleworkAgreement);

--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -332,8 +332,9 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
     Title: "Complete security training",
     Lead: RoleType.EMPLOYEE,
     TemplateId: templates.SecurityTraining,
-    Description: `<p style="margin-top: 0px">Review the Mandatory initial training slides and ensure you complete the survey at the end to receive credit</p>
-    <p>The slides can be found at <a href="https://usaf.dps.mil/:p:/r/teams/AFLCMCCSO/_layouts/15/Doc.aspx?sourcedoc=%7BC6E442DB-B72B-4AB6-9B80-1613F4281F48%7D&file=Initial%20CSO%20Training.pptx&action=edit&mobileredirect=true">https://usaf.dps.mil/:p:/r/teams/AFLCMCCSO/_layouts/15/Doc.aspx?sourcedoc=%7BC6E442DB-B72B-4AB6-9B80-1613F4281F48%7D&file=Initial%20CSO%20Training.pptx&action=edit&mobileredirect=true</p>`,
+    Description: `<p style="margin-top: 0px">To complete the mandatory security training please visit the AFLCMC Consolidated Security Office (CSO) In/Out Processing SharePoint site at the following URL:</p>
+    <p><a href="https://usaf.dps.mil/teams/AFLCMCCSO/SitePages/In-Out-Processing.aspx">https://usaf.dps.mil/teams/AFLCMCCSO/SitePages/In-Out-Processing.aspx</a></p>
+    <p>The CSO Initial Security Training Briefing is found by scrolling to the bottom of the page.  Please review these training slides and complete the survey at the end to ensure you receive credit for the training.</p>`,
     Prereqs: [templates.ProvisionAFNET],
   },
   {
@@ -501,7 +502,12 @@ const createInboundChecklistItems = (request: IInRequest) => {
   addChecklistItem(templates.AddSecurityGroups);
 
   // Signed Non-Disclosure Agreement (SF312) - Civ/Mil Only
-  addChecklistItem(templates.SignedNDA);
+  if (
+    request.empType === EMPTYPES.Civilian ||
+    request.empType === EMPTYPES.Military
+  ) {
+    addChecklistItem(templates.SignedNDA);
+  }
 
   // Complete security training
   addChecklistItem(templates.SecurityTraining);

--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -218,7 +218,7 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
     Title: "Confirm AFMC myETMS account",
     Lead: RoleType.SUPERVISOR,
     TemplateId: templates.ConfirmMyETMS,
-    Description: `<div><p style="margin-top: 0px">Click here for link to myETMS: <a href="https://myetms.wpafb.af.mil/myetmsasp/main.asp">Air Force Materiel Command's myEducation and Training Management System</a></p></div>`,
+    Description: `<div><p style="margin-top: 0px">Click here for link to myETMS: <a href="https://etmsweb.wpafb.af.mil/etmsaspx/mainx/profile.aspx?secId=-18911030">Air Force Materiel Command's myEducation and Training Management System</a></p></div>`,
     Prereqs: [templates.VerifyMyETMS],
   },
   {

--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -557,10 +557,12 @@ const createInboundChecklistItems = (request: IInRequest) => {
   // Unit orientation conducted (all Employees)
   addChecklistItem(templates.UnitOrientation);
 
-  // Create & brief 971 folder
-  addChecklistItem(templates.Brief971Folder);
+  // Create & brief 971 folder (Civilian Only)
+  if (request.empType === EMPTYPES.Civilian) {
+    addChecklistItem(templates.Brief971Folder);
+  }
 
-  // Signed performance/contribution plan
+  // Signed performance/contribution plan (Civilian Only)
   if (request.empType === EMPTYPES.Civilian) {
     addChecklistItem(templates.SignedPerformContribPlan);
   }

--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -133,7 +133,7 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
     Lead: RoleType.DTS,
     TemplateId: templates.DTS,
     Description: `<p style="margin-top: 0px">None</p>`,
-    Prereqs: [templates.GTC],
+    Prereqs: [templates.ObtainCACGov],
   },
   {
     Title: "Create/Update ATAAPS account",

--- a/src/components/CheckList/CheckListItemPrereq.tsx
+++ b/src/components/CheckList/CheckListItemPrereq.tsx
@@ -37,10 +37,15 @@ export const CheckListItemPrereq = ({
         return (
           <Badge
             size="extra-large"
+            key={item.Title}
             appearance="ghost"
+            aria-label={
+              item.Title +
+              (item.CompletedDate ? " is Complete" : " needs Completed")
+            }
             color={item.CompletedDate ? "success" : "informative"}
             style={{ verticalAlign: "middle", justifyContent: "flex-start" }}
-            icon={item.CompletedDate ? <CompletedIcon /> : ""}
+            icon={item.CompletedDate ? <CompletedIcon title="Complete" /> : ""}
             iconPosition="after"
           >
             {item.Title}

--- a/src/components/CheckList/__tests__/CheckListItemPrereq.tsx
+++ b/src/components/CheckList/__tests__/CheckListItemPrereq.tsx
@@ -1,0 +1,121 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import { ICheckListItem } from "api/CheckListItemApi";
+import { checklistTemplates } from "api/CreateChecklistItems";
+import { CheckListItemPrereq } from "components/CheckList/CheckListItemPrereq";
+import { DateTime } from "luxon";
+
+const queryClient = new QueryClient();
+
+const checklistAPI = require("api/CheckListItemApi");
+
+const testChecklistItems: ICheckListItem[] = checklistTemplates.map(
+  (template, index) => {
+    return {
+      Id: index + 1,
+      Title: template.Title,
+      Description: template.Description,
+      Lead: template.Lead,
+      RequestId: 1,
+      TemplateId: template.TemplateId,
+      Active: false,
+    };
+  }
+);
+
+describe("Prequisites shows incomplete", () => {
+  it.each(testChecklistItems)("$Title", async (item) => {
+    // Mock the useCheckListItems to return a checklist item for every defined template
+    jest
+      .spyOn(checklistAPI, "useChecklistItems")
+      .mockImplementation((requestId) => {
+        const testChecklistItems: ICheckListItem[] = checklistTemplates.map(
+          (template, index) => {
+            return {
+              Id: index + 1,
+              Title: template.Title,
+              Description: template.Description,
+              Lead: template.Lead,
+              RequestId: requestId as number,
+              TemplateId: template.TemplateId,
+              Active: false,
+            };
+          }
+        );
+
+        return { data: testChecklistItems };
+      });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CheckListItemPrereq checklistItem={item} />
+      </QueryClientProvider>
+    );
+
+    const thisTemp = checklistTemplates.find(
+      (templ) => templ.TemplateId === item.TemplateId
+    );
+
+    const preReqTitles = thisTemp?.Prereqs.map(
+      (id) => checklistTemplates.find((templ) => templ.TemplateId === id)?.Title
+    );
+
+    preReqTitles?.forEach((element) => {
+      const preReqElement = screen.getByLabelText(element + " needs Completed");
+      const completeIcon = within(preReqElement).queryByTitle("Complete");
+
+      // Expect the prerequisite to be listed
+      expect(preReqElement).toBeInTheDocument();
+      // Expect it NOT to have a checkmark icon showing it as Complete
+      expect(completeIcon).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("Prequisites shows completed", () => {
+  it.each(testChecklistItems)("$Title", async (item) => {
+    // Mock the useCheckListItems to return a checklist item for every defined template - and set CompletedDate
+    jest
+      .spyOn(checklistAPI, "useChecklistItems")
+      .mockImplementation((requestId) => {
+        const testChecklistItems: ICheckListItem[] = checklistTemplates.map(
+          (template, index) => {
+            return {
+              Id: index + 1,
+              Title: template.Title,
+              Description: template.Description,
+              Lead: template.Lead,
+              RequestId: requestId as number,
+              TemplateId: template.TemplateId,
+              CompletedDate: DateTime.now(),
+              Active: false,
+            };
+          }
+        );
+
+        return { data: testChecklistItems };
+      });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CheckListItemPrereq checklistItem={item} />
+      </QueryClientProvider>
+    );
+
+    const thisTemp = checklistTemplates.find(
+      (templ) => templ.TemplateId === item.TemplateId
+    );
+
+    const preReqTitles = thisTemp?.Prereqs.map(
+      (id) => checklistTemplates.find((templ) => templ.TemplateId === id)?.Title
+    );
+
+    preReqTitles?.forEach((element) => {
+      const preReqElement = screen.getByLabelText(element + " is Complete");
+      const completeIcon = within(preReqElement).getByTitle("Complete");
+
+      // Expect the prequisite to be listed
+      expect(preReqElement).toBeInTheDocument();
+      // Expect the prequisite to have a Complete icon
+      expect(completeIcon).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Update link in Confirm myETMS for supervisor (Closes #115)
Change the prereq for DTS from GTC to ObtainCACGov (Closes #116)
Make Signed Contribution plan (Closes #117) and 971 Folder (Closes #118) added only to Civilian
Update the link and description for Security Training to point to their In/Out page (Closes #120)
Fix Signed Non-Disclosure to not show for contractor (Only show for Civ/Mil) (Fixes #119)
Add testing to ensure CheckListItemPrereq component renders correctly for incomplete and complete prerequisities