### PR TITLE
Limit some fields to 100 chars to prevent SharePoint Error

### DIFF
--- a/src/components/InRequest/InRequestEditPanel.tsx
+++ b/src/components/InRequest/InRequestEditPanel.tsx
@@ -271,6 +271,10 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                 control={control}
                 rules={{
                   required: "Employee Name is required",
+                  maxLength: {
+                    value: 100,
+                    message: "Name cannot be longer than 100 characters",
+                  },
                   pattern: {
                     value: /\S/i,
                     message: "Employee Name is required",
@@ -568,7 +572,7 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
               workLocation === "remote" && (
                 <div className={classes.fieldContainer}>
                   <Label
-                    htmlFor="workLocationDetailId"
+                    id="workLocationDetailId"
                     size="small"
                     weight="semibold"
                     className={classes.fieldLabel}
@@ -583,12 +587,17 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                     rules={{
                       required:
                         "Remote Location is required for Remote Employees",
+                      maxLength: {
+                        value: 100,
+                        message:
+                          "Remote Location cannot be longer than 100 characters",
+                      },
                     }}
                     render={({ field }) => (
                       <Input
                         {...field}
                         aria-describedby="workLocationDetailErr"
-                        id="workLocationDetailId"
+                        aria-labelledby="workLocationDetailId"
                       />
                     )}
                   />
@@ -770,7 +779,7 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
               <>
                 <div className={classes.fieldContainer}>
                   <Label
-                    htmlFor="newCivId"
+                    id="isNewCivMilId"
                     size="small"
                     weight="semibold"
                     className={classes.fieldLabel}
@@ -790,6 +799,7 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                       <RadioGroup
                         {...field}
                         aria-describedby="isNewCivMilErr"
+                        aria-labelledby="isNewCivMilId"
                         id="newCivId"
                         disabled={true}
                       >
@@ -816,6 +826,11 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                       control={control}
                       rules={{
                         required: "Previous Organization is required",
+                        maxLength: {
+                          value: 100,
+                          message:
+                            "Previous Organization cannot be longer than 100 characters",
+                        },
                       }}
                       render={({ field }) => (
                         <Input
@@ -936,7 +951,7 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
               <>
                 <div className={classes.fieldContainer}>
                   <Label
-                    htmlFor="contractNumberId"
+                    id="contractNumberId"
                     size="small"
                     weight="semibold"
                     className={classes.fieldLabel}
@@ -950,12 +965,17 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
                     control={control}
                     rules={{
                       required: "Contract Number is required",
+                      maxLength: {
+                        value: 100,
+                        message:
+                          "Contract Number cannot be longer than 100 characters",
+                      },
                     }}
                     render={({ field }) => (
                       <Input
                         {...field}
                         aria-describedby="contractNumberErr"
-                        id="contractNumberId"
+                        aria-labelledby="contractNumberId"
                       />
                     )}
                   />

--- a/src/components/InRequest/InRequestNewForm.tsx
+++ b/src/components/InRequest/InRequestNewForm.tsx
@@ -221,6 +221,10 @@ export const InRequestNewForm = () => {
           defaultValue={""}
           rules={{
             required: "Employee Name is required",
+            maxLength: {
+              value: 100,
+              message: "Name cannot be longer than 100 characters",
+            },
             pattern: {
               value: /\S/i,
               message: "Employee Name is required",
@@ -576,7 +580,7 @@ export const InRequestNewForm = () => {
         workLocation === "remote" && (
           <div className={classes.fieldContainer}>
             <Label
-              htmlFor="workLocationDetailId"
+              id="workLocationDetailId"
               size="small"
               weight="semibold"
               className={classes.fieldLabel}
@@ -591,12 +595,17 @@ export const InRequestNewForm = () => {
               defaultValue={""}
               rules={{
                 required: "Remote Location is required for Remote Employees",
+                maxLength: {
+                  value: 100,
+                  message:
+                    "Remote Location cannot be longer than 100 characters",
+                },
               }}
               render={({ field }) => (
                 <Input
                   {...field}
                   aria-describedby="workLocationDetailErr"
-                  id="workLocationDetailId"
+                  aria-labelledby="workLocationDetailId"
                 />
               )}
             />
@@ -773,7 +782,7 @@ export const InRequestNewForm = () => {
         <>
           <div className={classes.fieldContainer}>
             <Label
-              htmlFor="newCivId"
+              id="isNewCivMilId"
               size="small"
               weight="semibold"
               className={classes.fieldLabel}
@@ -801,7 +810,7 @@ export const InRequestNewForm = () => {
                     onChange(e, option);
                   }}
                   aria-describedby="isNewCivMilErr"
-                  id="newCivId"
+                  aria-labelledby="isNewCivMilId"
                 >
                   <Radio key={"yes"} value={"yes"} label="Yes" />
                   <Radio key={"no"} value={"no"} label="No" />
@@ -832,6 +841,11 @@ export const InRequestNewForm = () => {
                 defaultValue={""}
                 rules={{
                   required: "Previous Organization is required",
+                  maxLength: {
+                    value: 100,
+                    message:
+                      "Previous Organization cannot be longer than 100 characters",
+                  },
                 }}
                 render={({ field }) => (
                   <Input
@@ -973,7 +987,7 @@ export const InRequestNewForm = () => {
         <>
           <div className={classes.fieldContainer}>
             <Label
-              htmlFor="contractNumberId"
+              id="contractNumberId"
               size="small"
               weight="semibold"
               className={classes.fieldLabel}
@@ -988,12 +1002,17 @@ export const InRequestNewForm = () => {
               defaultValue={""}
               rules={{
                 required: "Contract Number is required",
+                maxLength: {
+                  value: 100,
+                  message:
+                    "Contract Number cannot be longer than 100 characters",
+                },
               }}
               render={({ field }) => (
                 <Input
                   {...field}
                   aria-describedby="contractNumberErr"
-                  id="contractNumberId"
+                  aria-labelledby="contractNumberId"
                 />
               )}
             />

--- a/src/components/InRequest/__tests__/InRequestEditPanel.tsx
+++ b/src/components/InRequest/__tests__/InRequestEditPanel.tsx
@@ -9,12 +9,13 @@ import {
   fieldLabels,
   checkForInputToExist,
   isNotApplicable,
+  checkForErrorMessage,
+  lengthTest,
 } from "components/InRequest/__tests__/TestData";
 import { InRequestEditPanel } from "components/InRequest/InRequestEditPanel";
 import { SENSITIVITY_CODES } from "constants/SensitivityCodes";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { IInRequest } from "api/RequestApi";
-import { EMPTYPES } from "constants/EmpTypes";
 import { SAR_CODES } from "constants/SARCodes";
 
 const queryClient = new QueryClient();
@@ -385,6 +386,25 @@ describe("Remote Location", () => {
       );
     }
   );
+
+  it.each(lengthTest)(
+    "cannot exceed 100 characters - $testString.length",
+    async ({ testString }) => {
+      // Civilian Request has the location set to Remote
+      renderEditPanelForRequest(civRequest);
+
+      await checkEnterableTextbox(fieldLabels.REMOTE_LOCATION.form, testString);
+
+      const remLocFld = screen.getByRole("textbox", {
+        name: fieldLabels.REMOTE_LOCATION.form,
+      });
+      checkForErrorMessage(
+        remLocFld,
+        fieldLabels.REMOTE_LOCATION.lengthError,
+        testString.length > 100
+      );
+    }
+  );
 });
 
 describe("Contract Number", () => {
@@ -410,6 +430,23 @@ describe("Contract Number", () => {
       ctrRequest.contractNumber
     );
   });
+
+  it.each(lengthTest)(
+    "cannot exceed 100 characters - $testString.length",
+    async ({ testString }) => {
+      renderEditPanelForRequest(ctrRequest);
+      await checkEnterableTextbox(fieldLabels.CONTRACT_NUMBER.form, testString);
+
+      const ctrNumberFld = screen.getByRole("textbox", {
+        name: fieldLabels.CONTRACT_NUMBER.form,
+      });
+      checkForErrorMessage(
+        ctrNumberFld,
+        fieldLabels.CONTRACT_NUMBER.lengthError,
+        testString.length > 100
+      );
+    }
+  );
 });
 
 describe("Contract End Date", () => {
@@ -481,6 +518,45 @@ describe("Requires SCI", () => {
         name: fieldLabels.REQUIRES_SCI.form,
       });
       expect(sci).not.toBeInTheDocument();
+    }
+  );
+});
+
+describe("Employee Name", () => {
+  it.each(lengthTest)(
+    "cannot exceed 100 characters - $testString.length",
+    async ({ testString }) => {
+      renderEditPanelForRequest(civRequest);
+      await checkEnterableTextbox(fieldLabels.EMPLOYEE_NAME.form, testString);
+
+      const empNameFld = screen.getByRole("textbox", {
+        name: fieldLabels.EMPLOYEE_NAME.form,
+      });
+      checkForErrorMessage(
+        empNameFld,
+        fieldLabels.EMPLOYEE_NAME.lengthError,
+        testString.length > 100
+      );
+    }
+  );
+});
+
+describe("Previous Org", () => {
+  it.each(lengthTest)(
+    "cannot exceed 100 characters - $testString.length",
+    async ({ testString }) => {
+      // Civ Request has isNewCivMil set to 'no', so that Previous Org is available
+      renderEditPanelForRequest(civRequest);
+      await checkEnterableTextbox(fieldLabels.PREVIOUS_ORG.form, testString);
+
+      const prevOrgFld = screen.getByRole("textbox", {
+        name: fieldLabels.PREVIOUS_ORG.form,
+      });
+      checkForErrorMessage(
+        prevOrgFld,
+        fieldLabels.PREVIOUS_ORG.lengthError,
+        testString.length > 100
+      );
     }
   );
 });

--- a/src/components/InRequest/__tests__/InRequestNewForm.tsx
+++ b/src/components/InRequest/__tests__/InRequestNewForm.tsx
@@ -13,6 +13,8 @@ import {
   remoteLocationOnlyDataset,
   checkForInputToExist,
   isNotApplicable,
+  checkForErrorMessage,
+  lengthTest,
 } from "components/InRequest/__tests__/TestData";
 import { SAR_CODES } from "constants/SARCodes";
 
@@ -407,6 +409,33 @@ describe("Remote Location", () => {
       );
     }
   );
+
+  it.each(lengthTest)(
+    "cannot exceed 100 characters - $testString.length",
+    async ({ testString }) => {
+      await renderThenSelectEmpType(EMPTYPES.Civilian);
+
+      // Locate the RadioGroup for Local/Remote and select Remote so Remote Location field appears
+      const localOrRemote = screen.getByRole("radiogroup", {
+        name: fieldLabels.LOCAL_OR_REMOTE.form,
+      });
+      const remoteBttn = within(localOrRemote).getByRole("radio", {
+        name: /remote/i,
+      });
+      await user.click(remoteBttn);
+
+      await checkEnterableTextbox(fieldLabels.REMOTE_LOCATION.form, testString);
+
+      const remLocFld = screen.getByRole("textbox", {
+        name: fieldLabels.REMOTE_LOCATION.form,
+      });
+      checkForErrorMessage(
+        remLocFld,
+        fieldLabels.REMOTE_LOCATION.lengthError,
+        testString.length > 100
+      );
+    }
+  );
 });
 
 describe("Contract Number", () => {
@@ -431,6 +460,23 @@ describe("Contract Number", () => {
       ctrRequest.contractNumber
     );
   });
+
+  it.each(lengthTest)(
+    "cannot exceed 100 characters - $testString.length",
+    async ({ testString }) => {
+      await renderThenSelectEmpType(EMPTYPES.Contractor);
+      await checkEnterableTextbox(fieldLabels.CONTRACT_NUMBER.form, testString);
+
+      const ctrNumberFld = screen.getByRole("textbox", {
+        name: fieldLabels.CONTRACT_NUMBER.form,
+      });
+      checkForErrorMessage(
+        ctrNumberFld,
+        fieldLabels.CONTRACT_NUMBER.lengthError,
+        testString.length > 100
+      );
+    }
+  );
 });
 
 describe("Contract End Date", () => {
@@ -538,6 +584,53 @@ describe("Requires SCI", () => {
         name: fieldLabels.REQUIRES_SCI.form,
       });
       expect(sci).not.toBeInTheDocument();
+    }
+  );
+});
+
+describe("Employee Name", () => {
+  it.each(lengthTest)(
+    "cannot exceed 100 characters - $testString.length",
+    async ({ testString }) => {
+      await renderThenSelectEmpType(EMPTYPES.Civilian);
+      await checkEnterableTextbox(fieldLabels.EMPLOYEE_NAME.form, testString);
+
+      const empNameFld = screen.getByRole("textbox", {
+        name: fieldLabels.EMPLOYEE_NAME.form,
+      });
+      checkForErrorMessage(
+        empNameFld,
+        fieldLabels.EMPLOYEE_NAME.lengthError,
+        testString.length > 100
+      );
+    }
+  );
+});
+
+describe("Previous Org", () => {
+  it.each(lengthTest)(
+    "cannot exceed 100 characters - $testString.length",
+    async ({ testString }) => {
+      await renderThenSelectEmpType(EMPTYPES.Civilian);
+
+      // Must select that Employee is not a new Civilian for the Previous Org to appear
+      const newCiv = screen.getByRole("radiogroup", {
+        name: fieldLabels.NEW_CIVMIL.form,
+      });
+      const noBttn = within(newCiv).getByLabelText(/no/i);
+      await user.click(noBttn);
+
+      await checkEnterableTextbox(fieldLabels.PREVIOUS_ORG.form, testString);
+
+      const prevOrgFld = screen.getByRole("textbox", {
+        name: fieldLabels.PREVIOUS_ORG.form,
+      });
+
+      checkForErrorMessage(
+        prevOrgFld,
+        fieldLabels.PREVIOUS_ORG.lengthError,
+        testString.length > 100
+      );
     }
   );
 });

--- a/src/components/InRequest/__tests__/TestData.ts
+++ b/src/components/InRequest/__tests__/TestData.ts
@@ -45,6 +45,7 @@ export const milRequest: IInRequest = {
 
 /* Incoming civilian example */
 /* With Local/Remote = 'remote' */
+/* With isNewCivMil = 'no' */
 export const civRequest: IInRequest = {
   Id: 2,
   empName: testUsers[1].Title,
@@ -105,6 +106,10 @@ export const remoteLocationOnlyDataset = remoteLocationDataset.filter(
 );
 
 export const fieldLabels = {
+  EMPLOYEE_NAME: {
+    form: /employee name/i,
+    lengthError: /name cannot be longer than 100 characters/i,
+  },
   POSITION_SENSITIVITY_CODE: {
     form: /position sensitivity code/i,
     formType: "combobox",
@@ -133,10 +138,12 @@ export const fieldLabels = {
   },
   REMOTE_LOCATION: {
     form: /remote location/i,
+    lengthError: /remote location cannot be longer than 100 characters/i,
   },
   CONTRACT_NUMBER: {
     form: /contract number/i,
     view: /contract number/i,
+    lengthError: /contract number cannot be longer than 100 characters/i,
   },
   CONTRACT_END_DATE: {
     form: /contract end date/i,
@@ -145,6 +152,13 @@ export const fieldLabels = {
   REQUIRES_SCI: {
     form: /does employee require sci access\?/i,
     view: /requires sci\?/i,
+  },
+  NEW_CIVMIL: {
+    form: /is employee a new air force (civilian|military)\?/i,
+  },
+  PREVIOUS_ORG: {
+    form: /previous organization/i,
+    lengthError: /previous organization cannot be longer than 100 characters/i,
   },
 };
 
@@ -174,3 +188,35 @@ export const isNotApplicable = (
   // Check that value is "" so it is displaying the placeholder
   expect(naFld).toHaveValue("");
 };
+
+/** Check that ensures error message is displayed if expected
+ * @param field The field obtained by Jest
+ * @param errMessage The error message we are checking for
+ * @param expected Whether we expect the error to be in the Document or not
+ */
+export const checkForErrorMessage = (
+  field: HTMLElement,
+  errMessage: RegExp,
+  expected: boolean
+) => {
+  if (expected) {
+    expect(field).toHaveAccessibleDescription(errMessage);
+  } else {
+    expect(field).not.toHaveAccessibleDescription(errMessage);
+  }
+};
+
+// Used internally to genrate strings of various length
+const lorem =
+  "Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sunt facilis provident omnis voluptates beatae ipsam earum porro maiores amet sed, libero laborum quasi delectus esse magni harum, et, impedit placeat.";
+
+/** Array of testStrings used to test length */
+export const lengthTest = [
+  { testString: lorem.substring(0, 200) },
+  { testString: lorem.substring(0, 150) },
+  { testString: lorem.substring(0, 101) },
+  { testString: lorem.substring(0, 100) },
+  { testString: lorem.substring(0, 99) },
+  { testString: lorem.substring(0, 50) },
+  { testString: lorem.substring(0, 2) },
+];


### PR DESCRIPTION
Prevent the following freeform single line of text from exceeding 100 characters (Closes #127)
- Employee Name
- Previous Organization
- Contract Number
- Remote Location