### PR TITLE
convert routes to use dynamic imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,16 +8,22 @@ import {
 import "App.css";
 import { AppHeader } from "components/AppHeader/AppHeader";
 import { Route } from "react-router-dom";
-import { Home } from "Home";
-import { Item } from "Item";
 import { ThemeProvider } from "@fluentui/react";
 import { FluentProvider, webLightTheme } from "@fluentui/react-components";
 import { ErrorProvider } from "providers/ErrorProvider";
 import { ErrorNotification } from "components/ErrorNotification/ErrorNotification";
 import { UserProvider } from "providers/UserProvider";
-import { Roles } from "components/Roles/Roles";
-import { InRequestNewForm } from "components/InRequest/InRequestNewForm";
-import { MyCheckListItems } from "components/MyCheckListItems/MyCheckListItems";
+import { lazy, Suspense } from "react";
+
+const Home = lazy(() => import("Home"));
+const Roles = lazy(() => import("components/Roles/Roles"));
+const Item = lazy(() => import("Item"));
+const InRequestNewForm = lazy(
+  () => import("components/InRequest/InRequestNewForm")
+);
+const MyCheckListItems = lazy(
+  () => import("components/MyCheckListItems/MyCheckListItems")
+);
 
 /** Create a React Router with the needed Routes using the Data API */
 const router = createHashRouter(
@@ -54,9 +60,9 @@ function MainLayout() {
 
 function App() {
   return (
-    <>
+    <Suspense fallback={<div>Loading...</div>}>
       <RouterProvider router={router}></RouterProvider>
-    </>
+    </Suspense>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,9 @@ function MainLayout() {
             <AppHeader />
             <ErrorProvider>
               <ErrorNotification />
-              <Outlet />
+              <Suspense fallback={<div>Loading...</div>}>
+                <Outlet />
+              </Suspense>
             </ErrorProvider>
           </ThemeProvider>
         </FluentProvider>
@@ -59,11 +61,7 @@ function MainLayout() {
 }
 
 function App() {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <RouterProvider router={router}></RouterProvider>
-    </Suspense>
-  );
+  return <RouterProvider router={router}></RouterProvider>;
 }
 
 export default App;

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -9,7 +9,7 @@ import { FunctionComponent } from "react";
 import { MyRequests } from "components/MyRequests/MyRequests";
 import { Link } from "react-router-dom";
 
-export const Home: FunctionComponent = (props) => {
+const Home: FunctionComponent = (props) => {
   return (
     <Stack>
       <Stack.Item align="center">
@@ -69,3 +69,5 @@ export const Home: FunctionComponent = (props) => {
     </Stack>
   );
 };
+
+export default Home;

--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -6,7 +6,8 @@ import { InRequest } from "components/InRequest/InRequest";
 import { UserContext } from "providers/UserProvider";
 import { useRequest } from "api/RequestApi";
 import { RoleType } from "api/RolesApi";
-export const Item: FunctionComponent = (props) => {
+
+const Item: FunctionComponent = (props) => {
   const { itemNum } = useParams();
   const currentUser = useContext(UserContext);
   const request = useRequest(Number(itemNum));
@@ -68,3 +69,5 @@ export const Item: FunctionComponent = (props) => {
     </div>
   );
 };
+
+export default Item;

--- a/src/components/InRequest/InRequestNewForm.tsx
+++ b/src/components/InRequest/InRequestNewForm.tsx
@@ -100,7 +100,7 @@ type IRHFInRequest = Omit<
   employee: IRHFIPerson;
 };
 
-export const InRequestNewForm = () => {
+const InRequestNewForm = () => {
   const classes = useStyles();
   const currentUser = useContext(UserContext).user;
   const addRequest = useAddRequest();
@@ -1220,3 +1220,5 @@ export const InRequestNewForm = () => {
     </form>
   );
 };
+
+export default InRequestNewForm;

--- a/src/components/InRequest/__tests__/InRequestNewForm.tsx
+++ b/src/components/InRequest/__tests__/InRequestNewForm.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { InRequestNewForm } from "components/InRequest/InRequestNewForm";
+import InRequestNewForm from "components/InRequest/InRequestNewForm";
 import { EMPTYPES } from "constants/EmpTypes";
 import { SENSITIVITY_CODES } from "constants/SensitivityCodes";
 import {

--- a/src/components/MyCheckListItems/MyCheckListItems.tsx
+++ b/src/components/MyCheckListItems/MyCheckListItems.tsx
@@ -33,7 +33,7 @@ const useStyles = makeStyles({
 });
 
 /** This is a component to display the Active CheckListItems that the current user can complete */
-export const MyCheckListItems = () => {
+const MyCheckListItems = () => {
   /** FluentUI Styling */
   const classes = useStyles();
 
@@ -249,3 +249,5 @@ export const MyCheckListItems = () => {
     </>
   );
 };
+
+export default MyCheckListItems;

--- a/src/components/Roles/Roles.tsx
+++ b/src/components/Roles/Roles.tsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const Roles: React.FunctionComponent = () => {
+const Roles: React.FunctionComponent = () => {
   const classes = useStyles();
 
   // Which view is selected
@@ -219,3 +219,5 @@ export const Roles: React.FunctionComponent = () => {
     </>
   );
 };
+
+export default Roles;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,9 +19,14 @@ async function prepareMSW() {
         print: { warning: () => void }
       ) {
         if (
+          // Ignore giving warning for things like the logo, the persona icons, etc
           req.url.pathname.startsWith("/favicon.ico") ||
-          req.url.pathname.startsWith("/manifest.json") ||
-          req.url.pathname.endsWith(".png") // Ignore giving warning for things like the logo, the persona icons, etc
+          req.url.pathname.endsWith(".png") ||
+          req.url.pathname.endsWith(".woff") ||
+          // Ignore giving warning for dynamic imports
+          req.url.pathname.endsWith(".ts") ||
+          req.url.pathname.endsWith(".tsx") ||
+          req.url.pathname.endsWith(".js")
         ) {
           return;
         }


### PR DESCRIPTION
Set the routes to be lazy loaded. 
We may want to include a better fallback component.
Check the assets folder after a build. This did reduce the index.js file from about 1500kB down to 750kB (before gzip).
I think most of what's left is FluentUI, React Router, and React Query.