### PR TITLE
reserves space in the Item component for the scrollbar

### DIFF
--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
     paddingRight: ".5em",
     gridTemplateColumns: "minmax(250px, 1fr)",
     scrollbarGutter: "stable",
-    height: "calc(100vh - 42px)",
+    height: "calc(100vh - 3em)", // Reserve 3em for NavHeader height
     overflowY: "auto",
   },
   requestTitle: {

--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
     paddingRight: ".5em",
     gridTemplateColumns: "minmax(250px, 1fr)",
     scrollbarGutter: "stable",
-    height: "calc(100vh - 3em)", // Reserve 3em for NavHeader height
+    maxHeight: "calc(100vh - 3em)", // Reserve 3em for NavHeader height
     overflowY: "auto",
   },
   requestTitle: {

--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -15,6 +15,9 @@ const useStyles = makeStyles({
     paddingLeft: ".5em",
     paddingRight: ".5em",
     gridTemplateColumns: "minmax(250px, 1fr)",
+    scrollbarGutter: "stable",
+    height: "calc(100vh - 42px)",
+    overflowY: "auto",
   },
   requestTitle: {
     // Text (Title1) component requires it to be set as a block for elipsis to work


### PR DESCRIPTION
Grid would reflow if scrollbar was needed after fetching checklist items.
Fix: Reserve space for scrollbar in the right hand gutter