### PR TITLE
Add some Out-processing tasks -- Update Separation reason -- Add Exception for DoD transfer

### DIFF
--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -55,6 +55,7 @@ enum templates {
   TurnInCAC = 45,
   ConfirmTurnInCAC = 46,
   RemoveSpecialAccess = 47,
+  GTCTransferMemo = 48,
 }
 
 // Active is a derived prop based on if there are Prereqs or not
@@ -495,6 +496,13 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
     Description: `<p style="margin-top: 0px">None</p>`,
     Prereqs: [],
   },
+  {
+    Title: "Complete GTC transfer memo",
+    Lead: RoleType.GTC,
+    TemplateId: templates.GTCTransferMemo,
+    Description: `<p style="margin-top: 0px">None</p>`,
+    Prereqs: [],
+  },
 ];
 
 const createInboundChecklistItems = async (request: IInRequest) => {
@@ -785,6 +793,16 @@ const createOutboundChecklistItems = async (request: IOutRequest) => {
     addChecklistItem(templates.SignedNDADebrief);
   }
 
+  // If they selected the employee has special access, then add the task from removing it
+  if (request.isSCI === "yes") {
+    addChecklistItem(templates.RemoveSpecialAccess);
+  }
+
+  // If they selected the employee has DTS/GTC then add the GTC checklist item
+  if (request.isTraveler === "yes") {
+    addChecklistItem(templates.GTCTransferMemo);
+  }
+
   // If it is a Civ/Mil who is Retiring or Separating then add task for Turning in CAC.  Add for all Contractors.
   // Exemption to this is if they are staying within DoD (Move to non-AF DOD organization)
   if (
@@ -800,11 +818,6 @@ const createOutboundChecklistItems = async (request: IOutRequest) => {
   // If it is a Ctr then add task for Confirming turning in CAC.
   if (request.empType === EMPTYPES.Contractor) {
     addChecklistItem(templates.ConfirmTurnInCAC);
-  }
-
-  // If they selected the employee has special access, then add the task from removing it
-  if (request.isSCI === "yes") {
-    addChecklistItem(templates.RemoveSpecialAccess);
   }
 
   // Wait for the responses to all come back from the batch

--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -58,6 +58,7 @@ enum templates {
   GTCTransferMemo = 48,
   GTCConfirmTransfer = 49,
   CloseATAAPS = 50,
+  DetachDTS = 51,
 }
 
 // Active is a derived prop based on if there are Prereqs or not
@@ -519,6 +520,13 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
     Description: `<p style="margin-top: 0px">None</p>`,
     Prereqs: [],
   },
+  {
+    Title: "Detach account from losing organization",
+    Lead: RoleType.DTS,
+    TemplateId: templates.DetachDTS,
+    Description: `<p style="margin-top: 0px">DTS Link:  <a href="https://dtsproweb.defensetravel.osd.mil/dtamaint/user/promptUserSearch">https://dtsproweb.defensetravel.osd.mil/dtamaint/user/promptUserSearch</a></p>`,
+    Prereqs: [],
+  },
 ];
 
 const createInboundChecklistItems = async (request: IInRequest) => {
@@ -814,10 +822,11 @@ const createOutboundChecklistItems = async (request: IOutRequest) => {
     addChecklistItem(templates.RemoveSpecialAccess);
   }
 
-  // If they selected the employee has DTS/GTC then add the GTC checklist items
+  // If they selected the employee has DTS/GTC then add the GTC/DTS checklist items
   if (request.isTraveler === "yes") {
     addChecklistItem(templates.GTCTransferMemo);
     addChecklistItem(templates.GTCConfirmTransfer);
+    addChecklistItem(templates.DetachDTS);
   }
 
   // If the employee is a Civ/Mil who is Retiring or Separating then add task for Closing ATAAPS

--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -786,10 +786,12 @@ const createOutboundChecklistItems = async (request: IOutRequest) => {
   }
 
   // If it is a Civ/Mil who is Retiring or Separating then add task for Turning in CAC.  Add for all Contractors.
+  // Exemption to this is if they are staying within DoD (Move to non-AF DOD organization)
   if (
     ((request.empType === EMPTYPES.Civilian ||
       request.empType === EMPTYPES.Military) &&
-      (isRetiringReason || isSeparatinggReason)) ||
+      (isRetiringReason || isSeparatinggReason) &&
+      request.outReason !== "Move to non-AF DOD organization") ||
     request.empType === EMPTYPES.Contractor
   ) {
     addChecklistItem(templates.TurnInCAC);

--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -57,6 +57,7 @@ enum templates {
   RemoveSpecialAccess = 47,
   GTCTransferMemo = 48,
   GTCConfirmTransfer = 49,
+  CloseATAAPS = 50,
 }
 
 // Active is a derived prop based on if there are Prereqs or not
@@ -511,6 +512,13 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
     Description: `<p style="margin-top: 0px">None</p>`,
     Prereqs: [templates.GTCTransferMemo],
   },
+  {
+    Title: "Close ATAAPS",
+    Lead: RoleType.ATAAPS,
+    TemplateId: templates.CloseATAAPS,
+    Description: `<p style="margin-top: 0px">None</p>`,
+    Prereqs: [],
+  },
 ];
 
 const createInboundChecklistItems = async (request: IInRequest) => {
@@ -810,6 +818,15 @@ const createOutboundChecklistItems = async (request: IOutRequest) => {
   if (request.isTraveler === "yes") {
     addChecklistItem(templates.GTCTransferMemo);
     addChecklistItem(templates.GTCConfirmTransfer);
+  }
+
+  // If the employee is a Civ/Mil who is Retiring or Separating then add task for Closing ATAAPS
+  if (
+    (request.empType === EMPTYPES.Civilian ||
+      request.empType === EMPTYPES.Military) &&
+    (isRetiringReason || isSeparatinggReason)
+  ) {
+    addChecklistItem(templates.CloseATAAPS);
   }
 
   // If it is a Civ/Mil who is Retiring or Separating then add task for Turning in CAC.  Add for all Contractors.

--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -56,6 +56,7 @@ enum templates {
   ConfirmTurnInCAC = 46,
   RemoveSpecialAccess = 47,
   GTCTransferMemo = 48,
+  GTCConfirmTransfer = 49,
 }
 
 // Active is a derived prop based on if there are Prereqs or not
@@ -503,6 +504,13 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
     Description: `<p style="margin-top: 0px">None</p>`,
     Prereqs: [],
   },
+  {
+    Title: "Confirm employee travel card re-assigned to new organization",
+    Lead: RoleType.GTC,
+    TemplateId: templates.GTCConfirmTransfer,
+    Description: `<p style="margin-top: 0px">None</p>`,
+    Prereqs: [templates.GTCTransferMemo],
+  },
 ];
 
 const createInboundChecklistItems = async (request: IInRequest) => {
@@ -798,9 +806,10 @@ const createOutboundChecklistItems = async (request: IOutRequest) => {
     addChecklistItem(templates.RemoveSpecialAccess);
   }
 
-  // If they selected the employee has DTS/GTC then add the GTC checklist item
+  // If they selected the employee has DTS/GTC then add the GTC checklist items
   if (request.isTraveler === "yes") {
     addChecklistItem(templates.GTCTransferMemo);
+    addChecklistItem(templates.GTCConfirmTransfer);
   }
 
   // If it is a Civ/Mil who is Retiring or Separating then add task for Turning in CAC.  Add for all Contractors.

--- a/src/constants/OutProcessReasons.ts
+++ b/src/constants/OutProcessReasons.ts
@@ -22,6 +22,7 @@ export const OUT_PROCESS_REASONS = [
     text: "Separating",
     items: [
       {
+        // Note:  If this text changes -- ensure the exemption conditional statement is also updated in CreateChecklistItems
         key: "Move to non-AF DOD organization",
         text: "Move to non-AF DOD organization",
       },

--- a/src/constants/OutProcessReasons.ts
+++ b/src/constants/OutProcessReasons.ts
@@ -26,8 +26,8 @@ export const OUT_PROCESS_REASONS = [
         text: "Move to non-AF DOD organization",
       },
       {
-        key: "Move to external (non-government) job",
-        text: "Move to external (non-government) job",
+        key: "Move to external (Non-DOD government / Non-government) job",
+        text: "Move to external (Non-DOD government / Non-government) job",
       },
       {
         key: "Move to external (government related contractor) job",


### PR DESCRIPTION
Add some Out-processing tasks:
1) Complete GTC transfer memo
2) Confirm employee travel card re-assigned to new organization
3) Close ATAAPS
4) Detach account from losing organization

Update wording on Separation reason entry
Add exemption to not add the Turn in CAC task if they are transferring to non-AF DoD component, as they can use AF CAC with any DoD