### PR TITLE
Code Cleanup

### DIFF
--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -1,12 +1,12 @@
-import { FunctionComponent, useContext } from "react";
+import { useContext } from "react";
 import { makeStyles, Title1 } from "@fluentui/react-components";
 import { useParams } from "react-router-dom";
-import { CheckList } from "components/CheckList/CheckList";
-import { InRequest } from "components/InRequest/InRequest";
 import { UserContext } from "providers/UserProvider";
 import { isInRequest, useRequest } from "api/RequestApi";
 import { RoleType } from "api/RolesApi";
+import { InRequest } from "components/InRequest/InRequest";
 import { OutRequest } from "components/OutRequest/OutRequest";
+import { CheckList } from "components/CheckList/CheckList";
 
 /* FluentUI Styling */
 const useStyles = makeStyles({
@@ -29,25 +29,23 @@ const useStyles = makeStyles({
   },
 });
 
-const Item: FunctionComponent = () => {
+const Item = () => {
   const { itemNum } = useParams();
   const currentUser = useContext(UserContext);
   const request = useRequest(Number(itemNum));
   const classes = useStyles();
 
-  let requestRoles: RoleType[];
-
   if (currentUser.roles === undefined) {
     return <div className={classes.requestItem}>Loading...</div>;
-  } else {
-    requestRoles = [...currentUser.roles];
-    if (request?.data?.supGovLead.Id === currentUser.user?.Id) {
-      requestRoles.push(RoleType.SUPERVISOR);
-      // If the current user is the Supervisor of the Request, then they also get the Employee role
-      requestRoles.push(RoleType.EMPLOYEE);
-    } else if (request?.data?.employee?.Id === currentUser.user?.Id) {
-      requestRoles.push(RoleType.EMPLOYEE);
-    }
+  }
+
+  let requestRoles = [...currentUser.roles];
+  if (request.data?.supGovLead?.Id === currentUser.user.Id) {
+    requestRoles.push(RoleType.SUPERVISOR);
+    // If the current user is the Supervisor of the Request, then they also get the Employee role
+    requestRoles.push(RoleType.EMPLOYEE);
+  } else if (request.data?.employee?.Id === currentUser.user.Id) {
+    requestRoles.push(RoleType.EMPLOYEE);
   }
 
   return (
@@ -59,13 +57,13 @@ const Item: FunctionComponent = () => {
               truncate
               className={classes.requestTitle}
               title={
-                isInRequest(request.data)
-                  ? "In"
-                  : "Out" + " Processing Request for " + request.data.empName
+                request.data.reqType +
+                " Processing Request for " +
+                request.data.empName
               }
               wrap={false}
             >
-              {isInRequest(request.data) ? "In" : "Out"} Processing Request for{" "}
+              {request.data.reqType} Processing Request for{" "}
               {request.data.empName}
             </Title1>
           </div>
@@ -87,7 +85,7 @@ const Item: FunctionComponent = () => {
       ) : (
         <div>Loading...</div>
       )}
-      {request?.error && request.error instanceof Error && (
+      {request.error && request.error instanceof Error && (
         <div>An error has occured: ${request.error.message}</div>
       )}
     </div>

--- a/src/api/UserApi.ts
+++ b/src/api/UserApi.ts
@@ -1,12 +1,15 @@
-import { IPersonaProps } from "@fluentui/react";
 import { TestImages } from "@fluentui/example-data";
 
 declare var _spPageContextInfo: any;
 
-export interface IPerson extends IPersonaProps {
+export interface IPerson {
   Id: number;
   Title: string;
   EMail: string;
+  text?: string;
+  secondaryText?: string;
+  imageUrl?: string;
+  imageInitials?: string;
 }
 
 /**
@@ -16,14 +19,18 @@ export interface IPerson extends IPersonaProps {
 export class Person implements IPerson {
   Id: number;
   Title: string;
+  EMail: string;
   text: string;
   secondaryText: string;
-  EMail: string;
   imageUrl?: string;
   imageInitials?: string;
 
   constructor(
-    person: IPerson = { Id: -1, Title: "", EMail: "" },
+    person: IPerson = {
+      Id: -1,
+      Title: "",
+      EMail: "",
+    },
     LoginName?: string
   ) {
     this.Id = person.Id;

--- a/src/api/UserApi.ts
+++ b/src/api/UserApi.ts
@@ -39,8 +39,10 @@ export class Person implements IPerson {
     }
     if (!this.imageUrl) {
       this.imageInitials =
-        this.Title.substr(this.Title.indexOf(" ") + 1, 1) +
-        this.Title.substr(0, 1);
+        this.Title.substring(
+          this.Title.indexOf(" ") + 1,
+          this.Title.indexOf(" ") + 2
+        ) + this.Title.substring(0, 1);
     }
   }
 }

--- a/src/components/AppHeader/ImpersonationForm.tsx
+++ b/src/components/AppHeader/ImpersonationForm.tsx
@@ -34,6 +34,7 @@ const useStyles = makeStyles({
 interface IImpersonateForm {
   /** The user object returned by RHF */ user: Person;
 }
+
 /** Component that displays a button to enable Impersonation
  *  Upon clicking, it prompts the user to select the appropriate impersonation action
  */
@@ -55,32 +56,24 @@ export const ImpersonationForm = () => {
   } = useForm<IImpersonateForm>();
 
   /**
-   * Take the form data (or no data) and if it was provided, then pass to the UserContext to update
-   * If it was not provided, then pass nothing to UserContext, so it resets to self
+   * Take the form data, lookup User, then pass to the UserContext impersonate function to update
    *
    * @param data The RHF data, or undefined
    * @returns a void Promise
    */
-  const performImpersonate = async (data: IImpersonateForm | undefined) => {
-    if (data) {
-      // Lookup the userId
-      const userId = (await spWebContext.web.ensureUser(data.user.EMail)).data
-        .Id;
-      // Create a new userData object, to pass to the impersonation function
-      const userData = { ...data.user, Id: userId };
-      userContext.impersonate(userData);
-      hideImpersonateDialog(); // Close the impersonation dialog
-    }
+  const performImpersonate = async (data: IImpersonateForm) => {
+    // Lookup the userId
+    const userId = (await spWebContext.web.ensureUser(data.user.EMail)).data.Id;
+    // Create a new userData object, to pass to the impersonation function
+    const userData = { ...data.user, Id: userId };
+    userContext.impersonate(userData);
+    hideImpersonateDialog(); // Close the impersonation dialog
   };
 
   /**
-   * Take the form data (or no data) and if it was provided, then pass to the UserContext to update
-   * If it was not provided, then pass nothing to UserContext, so it resets to self
-   *
-   * @param data The RHF data, or undefined
+   * Pass nothing to UserContext impersonate function, so it resets to self
    */
   const removeImpersonation = () => {
-    // Call the UserContext impersonate function with no defined data to remove the impersonation
     userContext.impersonate(undefined);
     hideImpersonateDialog(); // Close the impersonation dialog
   };

--- a/src/components/InRequest/InRequestEditPanel.tsx
+++ b/src/components/InRequest/InRequestEditPanel.tsx
@@ -89,21 +89,9 @@ export const InRequestEditPanel: FunctionComponent<IInRequestEditPanel> = (
 ) => {
   const classes = useStyles();
 
-  type IRHFIPerson = {
-    Id: number;
-    Title: string;
-    EMail: string;
-    text?: string;
-    imageUrl?: string;
-  };
-
   // Create a type to handle the IInRequest type within React Hook Form (RHF)
-  // This will allow for better typechecking on the RHF without it running into issues with the special IPerson type
-  type IRHFInRequest = Omit<IInRequest, "MPCN" | "supGovLead" | "employee"> & {
+  type IRHFInRequest = Omit<IInRequest, "MPCN"> & {
     MPCN?: string;
-    /* Make of special type to prevent RHF from erroring out on typechecking -- but allow for better form typechecking on all other fields */
-    supGovLead: IRHFIPerson;
-    employee?: IRHFIPerson;
   };
 
   const {

--- a/src/components/InRequest/InRequestNewForm.tsx
+++ b/src/components/InRequest/InRequestNewForm.tsx
@@ -74,27 +74,12 @@ const useStyles = makeStyles({
   listBox: { maxHeight: "15em" },
 });
 
-type IRHFIPerson = {
-  Id: number;
-  Title: string;
-  EMail: string;
-  text: string;
-  imageUrl?: string;
-};
-
 // Create a type to handle the IInRequest type within React Hook Form (RHF)
-// This will allow for better typechecking on the RHF without it running into issues with the special IPerson type
-type IRHFInRequest = Omit<
-  IInRequest,
-  "empType" | "workLocation" | "supGovLead" | "employee" | "MPCN"
-> & {
+type IRHFInRequest = Omit<IInRequest, "empType" | "workLocation" | "MPCN"> & {
   /* Allowthese to be "" so that RHF can set as Controlled rather than Uncontrolled that becomes Controlled */
   empType: EMPTYPES | "";
   workLocation: worklocation | "";
   MPCN: string;
-  /* Make of special type to prevent RHF from erroring out on typechecking -- but allow for better form typechecking on all other fields */
-  supGovLead: IRHFIPerson;
-  employee: IRHFIPerson;
 };
 
 const InRequestNewForm = () => {
@@ -188,7 +173,7 @@ const InRequestNewForm = () => {
             <PeoplePicker
               ariaLabel="Employee"
               aria-describedby="employeeErr"
-              selectedItems={value}
+              selectedItems={value ?? []}
               updatePeople={(items) => {
                 if (items?.[0]?.text) {
                   setValue("empName", items[0].text, { shouldValidate: true });

--- a/src/components/InRequest/__tests__/TestData.ts
+++ b/src/components/InRequest/__tests__/TestData.ts
@@ -1,21 +1,21 @@
 import { IInRequest } from "api/RequestApi";
-import { IPerson } from "api/UserApi";
+import { Person } from "api/UserApi";
 import { EMPTYPES } from "constants/EmpTypes";
 import { ByRoleMatcher, screen, within } from "@testing-library/react";
 
 test("Load Test Data file", () => {});
 
-export const testUsers: IPerson[] = [
-  {
+export const testUsers = [
+  new Person({
     Id: 1,
     Title: "Barb Akew (All)",
     EMail: "Barb Akew@localhost",
-  },
-  {
+  }),
+  new Person({
     Id: 2,
     Title: "Chris P. Bacon (IT)",
     EMail: "Chris P. Bacon@localhost",
-  },
+  }),
 ];
 
 /* Incoming military example */

--- a/src/components/OutRequest/OutRequestEditPanel.tsx
+++ b/src/components/OutRequest/OutRequestEditPanel.tsx
@@ -87,22 +87,6 @@ export const OutRequestEditPanel: FunctionComponent<IOutRequestEditPanel> = (
 ) => {
   const classes = useStyles();
 
-  type IRHFIPerson = {
-    Id: number;
-    Title: string;
-    EMail: string;
-    text?: string;
-    imageUrl?: string;
-  };
-
-  // Create a type to handle the IOutRequest type within React Hook Form (RHF)
-  // This will allow for better typechecking on the RHF without it running into issues with the special IPerson type
-  type IRHFOutRequest = Omit<IOutRequest, "supGovLead" | "employee"> & {
-    /* Make of special type to prevent RHF from erroring out on typechecking -- but allow for better form typechecking on all other fields */
-    supGovLead: IRHFIPerson;
-    employee: IRHFIPerson;
-  };
-
   const {
     control,
     handleSubmit,
@@ -110,7 +94,7 @@ export const OutRequestEditPanel: FunctionComponent<IOutRequestEditPanel> = (
     setValue,
     watch,
     reset,
-  } = useForm<IRHFOutRequest>({
+  } = useForm<IOutRequest>({
     criteriaMode:
       "all" /* Pass back multiple errors, so we can prioritize which one(s) to show */,
     mode: "onChange" /* Provide input directly as they input, so if entering bad data it will let them know */,
@@ -135,7 +119,7 @@ export const OutRequestEditPanel: FunctionComponent<IOutRequestEditPanel> = (
     props.onEditCancel(); // Call the passed in function to process in the parent component
   };
 
-  const updateThisRequest = (data: IRHFOutRequest) => {
+  const updateThisRequest = (data: IOutRequest) => {
     updateRequest.mutate(data as IOutRequest, {
       onSuccess: () => {
         // Close the edit panel on a succesful edit

--- a/src/components/OutRequest/OutRequestNewForm.tsx
+++ b/src/components/OutRequest/OutRequestNewForm.tsx
@@ -71,28 +71,16 @@ const useStyles = makeStyles({
   listBox: { maxHeight: "15em" },
 });
 
-type IRHFIPerson = {
-  Id: number;
-  Title: string;
-  EMail: string;
-  text: string;
-  imageUrl?: string;
-};
-
 // Create a type to handle the IOutRequest type within React Hook Form (RHF)
-// This will allow for better typechecking on the RHF without it running into issues with the special IPerson type
 type IRHFOutRequest = Omit<
   IOutRequest,
-  "empType" | "supGovLead" | "employee" | "workLocation" | "isSCI" | "hasSIPR"
+  "empType" | "workLocation" | "isSCI" | "hasSIPR"
 > & {
   /* Allow these to be "" so that RHF can set as Controlled rather than Uncontrolled that becomes Controlled */
   empType: EMPTYPES | "";
   workLocation: worklocation | "";
   isSCI: "yes" | "no" | "";
   hasSIPR: "yes" | "no" | "";
-  /* Make of special type to prevent RHF from erroring out on typechecking -- but allow for better form typechecking on all other fields */
-  supGovLead: IRHFIPerson;
-  employee: IRHFIPerson;
 };
 
 const OutRequestNewForm = () => {

--- a/src/components/OutRequest/__tests__/TestData.ts
+++ b/src/components/OutRequest/__tests__/TestData.ts
@@ -1,21 +1,21 @@
 import { IOutRequest } from "api/RequestApi";
-import { IPerson } from "api/UserApi";
+import { Person } from "api/UserApi";
 import { EMPTYPES } from "constants/EmpTypes";
 import { ByRoleMatcher, screen, within } from "@testing-library/react";
 
 test("Load Test Data file", () => {});
 
-export const testUsers: IPerson[] = [
-  {
+export const testUsers = [
+  new Person({
     Id: 1,
     Title: "Barb Akew (All)",
     EMail: "Barb Akew@localhost",
-  },
-  {
+  }),
+  new Person({
     Id: 2,
     Title: "Chris P. Bacon (IT)",
     EMail: "Chris P. Bacon@localhost",
-  },
+  }),
 ];
 
 /* Incoming military example */


### PR DESCRIPTION
Replace deprecated substr with substring
Don't extend PnPJS type when we don't really use any of the extended props.  Rather define the ones we do use.  Allows for simplification of React Hook Form too, since the type is much less complex.
Cleanup ImpersonationForm comments
Simplify Item to remove unneeded IF condition, and use dynamic text over hardcoded In/Out
Remove uneeded state from the AddUserRolePanel due to better handling of the IPerson type
