### PR TITLE
Remove Signed NDA Debrief - No longer CC supervisor on task activation

### DIFF
--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -51,7 +51,6 @@ enum templates {
   RemovalFromWHAT = 41,
   TurnInSIPR = 42,
   SignedAF2587 = 43,
-  SignedNDADebrief = 44,
   TurnInCAC = 45,
   ConfirmTurnInCAC = 46,
   RemoveSpecialAccess = 47,
@@ -472,13 +471,6 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
     Prereqs: [],
   },
   {
-    Title: "Signed debrief section of Non-Disclosure Agreement (NDA)",
-    Lead: RoleType.SECURITY,
-    TemplateId: templates.SignedNDADebrief,
-    Description: `<p style="margin-top: 0px">None</p>`,
-    Prereqs: [],
-  },
-  {
     Title: "Turn-in Common Access Card (CAC)",
     Lead: RoleType.EMPLOYEE,
     TemplateId: templates.TurnInCAC,
@@ -822,15 +814,6 @@ const createOutboundChecklistItems = async (request: IOutRequest) => {
     (isRetiringReason || isSeparatinggReason)
   ) {
     addChecklistItem(templates.SignedAF2587);
-  }
-
-  // If the employee is a Civ/Mil who is Retiring or Separating then add task for Signed NDA Debrief
-  if (
-    (request.empType === EMPTYPES.Civilian ||
-      request.empType === EMPTYPES.Military) &&
-    (isRetiringReason || isSeparatinggReason)
-  ) {
-    addChecklistItem(templates.SignedNDADebrief);
   }
 
   // If they selected the employee has special access, then add the task from removing it

--- a/src/api/EmailApi.ts
+++ b/src/api/EmailApi.ts
@@ -163,7 +163,6 @@ export const useSendActivationEmails = (completedChecklistItemId: number) => {
 
       const newEmail: IEmail = {
         to: leadUsers,
-        cc: [request.supGovLead],
         subject: `(Action Required) ${request.reqType}-processing Checklist Item Active: New checklist item(s) available for ${request.empName}`,
         body: `The following checklist item(s) are now available to be completed:<ul>${items
           .map((item) => `<li>${item.Title}</li>`)


### PR DESCRIPTION
1)  Remove the "Signed debrief section of Non-Disclosure Agreement (NDA)" out-processing task as it is duplicative of signing the 2587 (Termination Statement)
2)  No longer CC the supervisor upon the activation of tasks







