### PR TITLE
Add SharePoint Group Management - Fix mock for role deletion

### DIFF
--- a/src/components/Roles/AddUserRolePanel.tsx
+++ b/src/components/Roles/AddUserRolePanel.tsx
@@ -127,7 +127,8 @@ export const AddUserRolePanel: FunctionComponent<IAddUserRolePanel> = (
           },
         });
       } else {
-        updateRole.mutate(roleData, {
+        const updateData = { old: { ...props.editItem }, new: { ...roleData } };
+        updateRole.mutate(updateData, {
           onSuccess: () => {
             setTimeout(() => {
               props.onClose();

--- a/src/components/Roles/Roles.tsx
+++ b/src/components/Roles/Roles.tsx
@@ -216,7 +216,7 @@ const Roles: React.FunctionComponent = () => {
             onClick={() => {
               for (let entry of selectedItems) {
                 let spRoleEntry = entry as SPRole;
-                removeRole.mutate(spRoleEntry.Id);
+                removeRole.mutate(spRoleEntry);
               }
             }}
           >

--- a/src/providers/SPWebContext.ts
+++ b/src/providers/SPWebContext.ts
@@ -3,6 +3,7 @@ import "@pnp/sp/webs";
 import "@pnp/sp/lists/web";
 import "@pnp/sp/items/list";
 import "@pnp/sp/site-users/web";
+import "@pnp/sp/site-groups/web"; // Used by RolesApi
 import "@pnp/sp/profiles";
 import "@pnp/sp/batching";
 


### PR DESCRIPTION
Added SharePoint Group Management, so that as users are added/removed from a role, it updates the SharePoint groups
Fixed the mock for Deletion of a role entry to actually work correctly