### PR TITLE
Fix Dismiss button on ChecklistItem panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - (Keep your changes here until you have a release version)
 
+## [2.1.4] - 2026-04-27
+
+### Fixed
+
+- Dismiss on Panel didn't work if you navigated to a checklist item via "My Checklist Items", where it auto-opened the Checklist item
+
 ## [2.1.3] - 2026-03-12
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "in-out-process",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "in-out-process",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "dependencies": {
         "@fluentui/example-data": "^8.4.12",
         "@fluentui/react": "^8.112.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "in-out-process",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "private": true,
   "homepage": ".",
   "type": "module",

--- a/src/components/CheckList/CheckList.tsx
+++ b/src/components/CheckList/CheckList.tsx
@@ -19,7 +19,7 @@ import { RoleType } from "api/RolesApi";
 import { IRequest } from "api/RequestApi";
 import { CheckListItemButton } from "components/CheckList/CheckListItemButton";
 import { DateTime } from "luxon";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 export interface ICheckList {
   ReqId: number;
@@ -39,11 +39,14 @@ export const CheckList: FunctionComponent<ICheckList> = (props) => {
 
   // React Router Hook to get the Route State
   const location = useLocation();
+  const navigate = useNavigate();
 
   if (location.state?.checklistItem && checklistItems.data) {
-    const checklistItem = location.state.checklistItem;
+    // Extract checklistItem and create a copy of the state without the property
+    const { checklistItem, ...newState } = location.state || {};
+
     const exists = checklistItems.data.find(
-      (item) => item.Id === parseInt(checklistItem)
+      (item) => item.Id === parseInt(checklistItem),
     );
     if (exists) {
       if (!currentItemId) {
@@ -54,14 +57,17 @@ export const CheckList: FunctionComponent<ICheckList> = (props) => {
       }
     }
 
-    // Clear the state without re-rendering the page
-    window.history.replaceState({}, "", location.hash);
+    // Navigate to the same URL, replacing the state - preventing clicks of "Dismiss" to keep opening the panel
+    navigate(location.pathname, {
+      replace: true,
+      state: newState,
+    });
   }
 
   // DataGrid method for when a new row is selected
   const onSelectionChange: DataGridProps["onSelectionChange"] = (_e, data) => {
     setCurrentItemId(
-      parseInt(data.selectedItems.values().next().value?.toString() ?? "")
+      parseInt(data.selectedItems.values().next().value?.toString() ?? ""),
     );
   };
 
@@ -166,7 +172,7 @@ export const CheckList: FunctionComponent<ICheckList> = (props) => {
 
   // The currently selected CheckList Item
   const currentItem = checklistItems.data?.find(
-    (item) => item.Id === currentItemId
+    (item) => item.Id === currentItemId,
   );
 
   return (


### PR DESCRIPTION
Dismiss button would not work on the Checklist Item Panel when it was opened via any of the special tasks from "My Checklist Items", due to it not actually clearing the temporary state. Example "Provision/move AFNET account".