### PR TITLE
Remove duplicative Test prefix on email subject and myETMS tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - No longer append "TEST - " to subject line of emails, as the Power Automate handles doing this if it is in the Sandbox
+- Remove the myETMS related tasks, as that training system was decomissioned
 
 ## [2.1.4] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - (Keep your changes here until you have a release version)
 
+## [2.1.5] - 2026-08-17
+
+### Changed
+
+- No longer append "TEST - " to subject line of emails, as the Power Automate handles doing this if it is in the Sandbox
+
 ## [2.1.4] - 2026-04-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "in-out-process",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "in-out-process",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "dependencies": {
         "@fluentui/example-data": "^8.4.12",
         "@fluentui/react": "^8.112.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "in-out-process",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "private": true,
   "homepage": ".",
   "type": "module",

--- a/src/api/CreateChecklistItems.ts
+++ b/src/api/CreateChecklistItems.ts
@@ -17,7 +17,6 @@ export enum templates {
   DTS = 7,
   ATAAPS = 8,
   VerifyMyLearn = 9,
-  VerifyMyETMS = 10,
   MandatoryTraining = 11,
   OrientationVideos = 13,
   Bookmarks = 14,
@@ -25,7 +24,6 @@ export enum templates {
   SupervisorTraining = 16,
   ConfirmMandatoryTraining = 17,
   ConfirmMyLearn = 18,
-  ConfirmMyETMS = 19,
   UnitOrientation = 20,
   Brief971Folder = 21,
   SignedPerformContribPlan = 22,
@@ -175,18 +173,11 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
     Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
   },
   {
-    Title: "Verify AFMC myETMS account",
-    Lead: RoleType.EMPLOYEE,
-    TemplateId: templates.VerifyMyETMS,
-    Description: `<div><p style="margin-top: 0px">Click here for link to myETMS: <a href="https://myetms.wpafb.af.mil/myetmsasp/main.asp">Air Force Materiel Command's myEducation and Training Management System</a></p></div>`,
-    Prereqs: [templates.ObtainCACCtr, templates.ObtainCACGov],
-  },
-  {
     Title: "Complete mandatory training",
     Lead: RoleType.EMPLOYEE,
     TemplateId: templates.MandatoryTraining,
     Description: `<p style="margin-top: 0px">For a list of mandatory training requirements, please find the document titled "Mandatory Training" at the following link: <a href="https://usaf.dps.mil/sites/22539/Docs%20Shared%20to%20All/XP%20InOut%20Processing%20Automation%20Links/Mandatory%20Training.docx">Mandatory Training.docx</a></p>`,
-    Prereqs: [templates.VerifyMyETMS, templates.VerifyMyLearn],
+    Prereqs: [templates.VerifyMyLearn],
   },
   {
     Title: "View orientation videos",
@@ -229,16 +220,6 @@ RAPIDS website: <a href="https://idco.dmdc.os.mil/idco/">https://idco.dmdc.os.mi
     TemplateId: templates.ConfirmMyLearn,
     Description: `<div><p style="margin-top: 0px">Click here for link to Air Force myLearning account: <a href="https://lms-jets.cce.af.mil/moodle/">Air Force MyLearning</a></p></div>`,
     Prereqs: [templates.VerifyMyLearn],
-  },
-  {
-    Title: "Confirm AFMC myETMS account",
-    Lead: RoleType.SUPERVISOR,
-    TemplateId: templates.ConfirmMyETMS,
-    Description: `<div><p style="margin-top: 0px">To confirm employee myETMS account, supervisors can access the ETMS WEB application which is for Supervisors, Training Managers, and Education Development Specialists at the following URL: <a href="https://etmsweb.wpafb.af.mil/">https://etmsweb.wpafb.af.mil/</a><p>
-<p>Once logged into ETMS WEB, select the "View All Employees" under "Quick Searches" on the left to see all your assigned employees who have registered myETMS accounts.</p> 
-<br/>
-<p>NOTE: It is also possible to access the ETMS WEB application through your standard myETMS account by looking for the ETMS WEB icon/link.</p></div>`,
-    Prereqs: [templates.VerifyMyETMS],
   },
   {
     Title: "Unit orientation conducted",
@@ -699,22 +680,6 @@ const createInboundChecklistItems = async (request: IInRequest) => {
 
   // Confirm Air Force myLearning account
   addChecklistItem(templates.ConfirmMyLearn);
-
-  // Verify AFMC myETMS account - CIV/MIL only
-  if (
-    request.empType === EMPTYPES.Civilian ||
-    request.empType === EMPTYPES.Military
-  ) {
-    addChecklistItem(templates.VerifyMyETMS);
-  }
-
-  // Confirm AFMC myETMS account - CIV/MIL Only
-  if (
-    request.empType === EMPTYPES.Civilian ||
-    request.empType === EMPTYPES.Military
-  ) {
-    addChecklistItem(templates.ConfirmMyETMS);
-  }
 
   // Mandatory training (all employees)
   addChecklistItem(templates.MandatoryTraining);

--- a/src/api/EmailApi.ts
+++ b/src/api/EmailApi.ts
@@ -57,7 +57,7 @@ interface ISendRequestCancelEmail {
 const getEmailAddresses = (people: IPerson[]) => {
   let emailArray = people.map((p) => p.EMail);
   const emailArrayNoDupes = emailArray.filter(
-    (n, i) => emailArray.indexOf(n) === i
+    (n, i) => emailArray.indexOf(n) === i,
   );
 
   return emailArrayNoDupes.join(";");
@@ -83,9 +83,7 @@ const transformEmailToSP = (email: IEmail) => {
     To: toAddresses,
     CC: email.cc ? getEmailAddresses(email.cc) : undefined,
     // Truncate the subject if it is going to exceed 255 characters so it doesn't error writing to field
-    Subject: (
-      (import.meta.env.MODE === "testing" ? "TEST - " : "") + email.subject
-    ).substring(0, 255),
+    Subject: email.subject.substring(0, 255),
     //Adjust line breaks so they show nicely even when Outlook converts to plaintext
     Body: email.body.replace(/\n/g, "\r\n<BR />"),
     SupGovLead: email.supGovLead,
@@ -121,7 +119,7 @@ export const useSendActivationEmails = (completedChecklistItemId: number) => {
 
     // Get the request details for use in the email
     const request = transformRequestFromSP(
-      await queryClient.fetchQuery(["request", reqId], () => getRequest(reqId))
+      await queryClient.fetchQuery(["request", reqId], () => getRequest(reqId)),
     );
 
     // Loop through the Map of checklist items that just became active, which are grouped by lead
@@ -133,7 +131,7 @@ export const useSendActivationEmails = (completedChecklistItemId: number) => {
           item.Id !== completedChecklistItemId && // Don't include the item just completed
           item.Lead === lead && // Items for this Lead/POC
           item.Active && // which are Active
-          !item.CompletedDate // and not yet completed
+          !item.CompletedDate, // and not yet completed
       );
 
       if (oustandingItems.length > 0) {
@@ -169,7 +167,7 @@ export const useSendActivationEmails = (completedChecklistItemId: number) => {
         body: `The following checklist item(s) are now available to be completed:<ul>${items
           .map((item) => `<li>${item.Title}</li>`)
           .join(
-            ""
+            "",
           )}</ul>${outstandingMessage}<br/>To view this request and take action follow the below link:<br/><a href="${linkURL}">${linkURL}</a>`,
         supGovLead: request.supGovLead.EMail,
       };
@@ -215,7 +213,7 @@ export const useSendRequestSubmitEmail = () => {
 
     // Remove any duplicates from the array so we can loop through and process each lead only once
     const leads = leadsWithDupes.filter(
-      (n, i) => leadsWithDupes.indexOf(n) === i
+      (n, i) => leadsWithDupes.indexOf(n) === i,
     );
 
     let leadUsers: IPerson[] = [];
@@ -323,7 +321,7 @@ export const useSendRequestCancelEmail = () => {
 
     // Remove any duplicates from the array so we can loop through and process each lead only once
     const leads = leadsWithDupes.filter(
-      (n, i) => leadsWithDupes.indexOf(n) === i
+      (n, i) => leadsWithDupes.indexOf(n) === i,
     );
 
     let leadUsers: IPerson[] = [];
@@ -425,7 +423,7 @@ export const useSendRequestVerifyCompleteEmail = (reqId: number) => {
   const sendInRequestVerifyCompleteEmail = async () => {
     // Get the request details for use in the email
     const request = transformRequestFromSP(
-      await queryClient.fetchQuery(["request", reqId], () => getRequest(reqId))
+      await queryClient.fetchQuery(["request", reqId], () => getRequest(reqId)),
     );
 
     const linkURL = `<a href="${webUrl}/app/index.aspx#/item/${request.Id}">${webUrl}/app/index.aspx#/item/${request.Id}</a>`;


### PR DESCRIPTION
Remove the duplicative "TEST - " prefix on emails generated in a TEST version of the app as the Power Automate now does on any from Sandbox

Remove the myETMS tasks, as that training system has been decomissioned.